### PR TITLE
runtime redis api test and fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
-version = 0.0.31.dev3
+version = 0.0.32
 license_files = LICENSE
 

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -1,13 +1,14 @@
+import types
 from functools import lru_cache
 
-from redgrease import execute
+import redgrease
 from redgrease.client import RedisGears
 
 
 def runtime_execute_command(self, *args, **options):
     "Execute a command in local Gear runtime and return a parsed response"
     command_name = args[0]
-    response = execute(*args)
+    response = redgrease.execute(*args)
     if command_name in self.response_callbacks:
         return self.response_callbacks[command_name](response, **options)
     return response
@@ -16,11 +17,13 @@ def runtime_execute_command(self, *args, **options):
 @lru_cache()
 def get_runtime_client():
     runtime_client = RedisGears(connection_pool=...)
-    runtime_client.execute_command = runtime_execute_command
+    runtime_client.execute_command = types.MethodType(
+        runtime_execute_command, runtime_client
+    )
     return runtime_client
 
 
-execute = get_runtime_client()  # noqa: F811 - Used as exported var
+api = get_runtime_client()  # noqa: F811 - Used as exported var
 
 
 # ## Redis v6 commands

--- a/tests/gear_scripts/redgrease_runtime_redis_api_get_set.py
+++ b/tests/gear_scripts/redgrease_runtime_redis_api_get_set.py
@@ -1,0 +1,33 @@
+import redgrease
+import redgrease.runtime
+
+
+def double(record):
+
+    try:
+        val = record["value"]
+        key = record["key"]
+    except KeyError as ex:
+        err_msg = f"Record {record}, does not seem to be a normal record"
+        redgrease.log(err_msg + f": {ex}")
+        raise ValueError(err_msg) from ex
+
+    try:
+        val = redgrease.runtime.api.get(key)
+    except Exception as ex:
+        err_msg = f"Unable to get key '{key}'"
+        redgrease.log(err_msg + f": {ex}")
+        raise KeyError(err_msg) from ex
+
+    try:
+        val = float(val)
+    except Exception as ex:
+        err_msg = f"The value of the key {key} did not float very well"
+        redgrease.log(err_msg + f": {ex}. Blubb, blubb!")
+        raise TypeError(err_msg) from ex
+    else:
+        val *= 2
+        redgrease.runtime.api.set(key, val)
+
+
+redgrease.GB(redgrease.Reader.KeysReader).foreach(double).run()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,6 @@ from redgrease.client import RedisGears, safe_str, str_if_bytes
 
 # Other things to test:
 # - Syntactinc sugar / enums
-# - runtime 'client'
 # - cli / loader
 
 
@@ -241,16 +240,39 @@ def test_abortexecution(rg: RedisGears):
     assert False
 
 
-@pytest.mark.xfail(reason="Testcase not implemented")
 def test_pystats(rg: RedisGears):
-    assert False
+    stats = rg.gears.pystats()
+    assert stats
+    assert isinstance(stats, redgrease.client.PyStats)
+
+    assert stats.TotalAllocated
+    assert isinstance(stats.TotalAllocated, int)
+    assert stats.TotalAllocated > 0
+
+    assert stats.PeakAllocated
+    assert isinstance(stats.PeakAllocated, int)
+    assert stats.PeakAllocated > 0
+
+    assert stats.CurrAllocated
+    assert isinstance(stats.CurrAllocated, int)
+    assert stats.CurrAllocated > 0
 
 
-@pytest.mark.xfail(reason="Testcase not implemented")
-def test_infocluster(rg: RedisGears):
-    assert False
+# TODO: Actually test on a cluster setup
+@pytest.mark.parametrize("cluster_mode", [False])
+def test_infocluster(rg: RedisGears, cluster_mode):
+    info = rg.gears.infocluster()
+    # Non-c
+    if not cluster_mode:
+        assert info is None
+        return
+
+    assert info
 
 
-@pytest.mark.xfail(reason="Testcase not implemented")
+# TODO: Actually test on a cluster setup
 def test_refreshcluster(rg: RedisGears):
-    assert False
+    # Pretty pointless test, but anyway
+    # TODO: Somehow validate that it is run... Unsure of how though
+    # TODO: See issue #11
+    assert rg.gears.refreshcluster()

--- a/tests/test_runtime_redis_api.py
+++ b/tests/test_runtime_redis_api.py
@@ -1,0 +1,55 @@
+import os
+from pathlib import Path
+
+import pytest
+import redis.exceptions
+
+from redgrease.client import RedisGears, safe_str
+
+scripts_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gear_scripts")
+
+
+def gear_script(file):
+    return os.path.join(scripts_dir, file)
+
+
+def gear_scripts(file_pattern):
+    directory = Path(str(scripts_dir))
+    return directory.rglob(file_pattern)
+
+
+def read(file_pattern):
+    directory = Path(str(scripts_dir))
+    files_contents = []
+    for file_path in directory.rglob(file_pattern):
+        with open(file_path, "r") as file:
+            files_contents.append((file_path.name, file.read()))
+    return files_contents
+
+
+@pytest.mark.parametrize(
+    "script", read("redgrease_runtime_redis_api_*.py"), ids=lambda x: x[0][-10:]
+)
+def test_basic(rg: RedisGears, script):
+    script_name, script_contents = script
+    # First set no keys
+    res_0 = rg.gears.pyexecute(script_contents)
+    assert res_0
+    assert res_0.results == []
+
+    orig_val = 13
+    key = "NUM"
+
+    assert rg.set(key, orig_val)
+
+    res_1 = rg.gears.pyexecute(script_contents)
+    assert res_1
+    assert res_1.results
+    assert res_1.errors == []
+
+    assert float(safe_str(rg.get(key))) == orig_val * 2
+
+
+"""
+b"{'event': None, 'key': 'NUM', 'type': 'string', 'value': '13'}"
+"""


### PR DESCRIPTION
# Related Issue(s):
issue #7 

# Main Changes:
- added test for gear scripts that utilize the Redis 'client' expodsed through `redgrease.runtime.api` (instead of using `execute`)
- added minimal tests for `pystats`, `refreshcluster` and `infocluster`

# Additionl 
not really

# Checklist
(Check those that apply, just so we know)
- [ ] Ad-hoc/manual testing
- [x] Ran relveant pytest's 
    (I.e some test cases only)
- [x] Ran whole pytest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [ ] Ran whole nox test suite 
    (I.e. all test-casese across all supported environments)
- [ ] Documentation
