### PR TITLE
ReadTheDocs skellington

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8
+  install:
+  - requirements: docs/source/requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,33 +4,33 @@ RedGrease is a Python package and set of tools to facilitate development against
 
 RedGrease consists of the followinig, components:
 
-- [A Redis / Redis Gears client](#client) (`redgrease.client.RedisGears`), which is an extended version of the [redis](https://pypi.org/project/redis/) client, but with additional pythonic functions, mapping closely (1-to-1) to the Redis Gears command set (e.g. `RG.PYEXECUTE`, `RG.GETRESULT`, `RG.TRIGGER`, `RG.DUMPREGISTRATIONS` etc), outlined [here](https://oss.redislabs.com/redisgears/commands.html)
-```
+1. [A Redis / Redis Gears client](https://redgrease.readthedocs.io) (`redgrease.client.RedisGears`), which is an extended version of the [redis](https://pypi.org/project/redis/) client, but with additional pythonic functions, mapping closely (1-to-1) to the Redis Gears command set (e.g. `RG.PYEXECUTE`, `RG.GETRESULT`, `RG.TRIGGER`, `RG.DUMPREGISTRATIONS` etc), outlined [here](https://oss.redislabs.com/redisgears/commands.html)
+```python
 from redgrease.client import RedisGears
 
 rg = RedisGears()
 rg.gears.pyexecute("GB().run()")  # <--
 ```
 
-- Some [helper runtime functions](#builtin-runtime-functions) defined in(#builtin-runtime-functions) `redgrease.runtime`, but also exposed at 'top-level' (`redgrease`), exposing placeholders for the built-in Redis Gears functions (e.g. `GearsBuilder`, `GB`, `atomic`, `execute`, `log` etc) that are automatically loaded into the server [runtime environment](https://oss.redislabs.com/redisgears/runtime.html). These placeholder versions provide auto completion and type hints during development, and does not clash with the actual runtime, i.e does not require redgrease to be installed on the server.
+2. Some [helper runtime functions](https://redgrease.readthedocs.io) defined in(#builtin-runtime-functions) `redgrease.runtime`, but also exposed at 'top-level' (`redgrease`), exposing placeholders for the built-in Redis Gears functions (e.g. `GearsBuilder`, `GB`, `atomic`, `execute`, `log` etc) that are automatically loaded into the server [runtime environment](https://oss.redislabs.com/redisgears/runtime.html). These placeholder versions provide auto completion and type hints during development, and does not clash with the actual runtime, i.e does not require redgrease to be installed on the server.
 ![basic hints](docs/images/basic_usage_hints.jpg)
 
-- [Syntactic sugar](#syntactic-sugar) for various things like 'magic' values and strings, like the different reader names (e.g `redgrease.Reader.CommandReader`), trigger modes (e.g. `redgrease.TriggerMode.AsyncLocal`) and log levels (e.g. `redgrease.LogLevel.Notice`). 
-```
-from redgrease import GB, execute, hashtag, Reader, TriggerMode
+3. [Syntactic sugar](https://redgrease.readthedocs.io) for various things like 'magic' values and strings, like the different reader names (e.g `redgrease.Reader.CommandReader`), trigger modes (e.g. `redgrease.TriggerMode.AsyncLocal`) and log levels (e.g. `redgrease.LogLevel.Notice`). 
+```python
+from redgrease import GB, execute, hashtag, Reader, TriggerMode, cmd
 
 
 cap = GB(Reader.StreamReader)  # <--
 cap.foreach(lambda x:
-            execute('XADD', f'expired:{hashtag()}', '*', 'key', x['key']))
+            cmd.xadd(f'expired:{hashtag()}', '*', 'key', x['key']))
 cap.register(prefix='*',
              mode=TriggerMode.Async,  # <-- 
              eventTypes=['expired'],
              readValue=False)
 ```
 
-- [Servers-side Redis commands](#serverside-redis-commands), allowing for all Redis (v.6) commands to be executed on serverside as if using a Redis 'client' class, instead of 'manually' invoking the `execute()`. It is basically the [redis](https://pypi.org/project/redis/) client, but with `execute_command` rewired to use the Gears-native `execute` instead under the hood. 
-```
+4. [Servers-side Redis commands](https://redgrease.readthedocs.io), allowing for all Redis (v.6) commands to be executed on serverside as if using a Redis 'client' class, instead of 'manually' invoking the `execute()`. It is basically the [redis](https://pypi.org/project/redis/) client, but with `execute_command` rewired to use the Gears-native `execute` instead under the hood. 
+```python
 import redgrease
 
 
@@ -51,12 +51,15 @@ def double(record):
 redgrease.GB(redgrease.Reader.KeysReader).foreach(double).run()
 ```
 
-- [Loader CLI](#loader-cli) and Docker image, for automatic loading of Gears scripts, mainly "trigger-based" CommandReader Gears, into a Redis Gears cluster. It also provides a simple form of 'hot-reloading' of Redis Gears scripts, by continously monitoring directories containing Redis Gears scripts and automatically 'pyexecute' them on a Redis Gear instance if it detects modifications. 
+4. [Loader CLI](https://redgrease.readthedocs.io) and Docker image, for automatic loading of Gears scripts, mainly "trigger-based" CommandReader Gears, into a Redis Gears cluster. It also provides a simple form of 'hot-reloading' of Redis Gears scripts, by continously monitoring directories containing Redis Gears scripts and automatically 'pyexecute' them on a Redis Gear instance if it detects modifications. 
 The purpose is mainly to streamline development of 'trigger-style' Gear scripts by providing a form of hot-reloading functionality.
-
-
-- **[Work-in-Progress]** A [remote GearsBuilder](#remote-gears), inspired by the official [redisgears-py](https://github.com/RedisGears/redisgears-py) client, but with some differences.
 ```
+redgrease --server 10.0.2.21 --watch scripts/
+```
+This will 'pyexecute' the gears scripts in the 'scripts' directory against the server. It will also watch the directors for changes and re-execute the scripts if they have been modified.
+
+5. **[Work-in-Progress]** A [remote GearsBuilder](https://redgrease.readthedocs.io), inspired by the official [redisgears-py](https://github.com/RedisGears/redisgears-py) client, but with some differences.
+```python
 from redgrease.client import RedisGears
 from redgrease.reader import CommandReader
 from redgrease import log
@@ -64,7 +67,7 @@ from redgrease import log
 rg = RedisGears()
 
 def process(x):
-    log(f"Processing '{x}')
+    log(f"Processing '{x}'")
     return x
 
 my_command = CommandReader().flatmap(lambda x: x)
@@ -73,14 +76,21 @@ my_command.register(rg, trigger="bang")
 rg.gears.trigger("bang")
 ```
 
-- **[Soonish]** Other useful and/or boilerplate functions, commonly used in gears. Suggestions appriciated. 
+6. **[In Backlog]** Other boilerplate or otherwise functions, that may commonly be used in gears. e.g:
+    - A simple `records()` function  that can be used to transform the default `KeysReader` dict to an `Records` object with the appropriate attributes. Maybe even sertter for the value (?)
+    ```python
+    KeysReader().map(redgrease.record).foreach(lambda r: log(f"The key '{r[.key]}' is of type '{r.type}' with value '{r.valuer}'")
+    ```
+    - Helpers to aid debugging and/ or testing of gears. 
+    - ...
 
-# Why?
-
-Note that the RedGrease package is primarily intended to aid development of Gears scripts, and can be useful even if it is not installed in the Redis Gears runtime environment, although it may be the most convenient approach.
+Suggestions appriciated.
 
 # Installation
-### Development Environment
+Redgrease may be installed either as a developmet tool only, a client library and/or as a runtime library on the Redis Gears server.
+It can be installed with different 'extras', dependencies depending on preferred usage. 
+
+## Development / Client Environment Install
 In the environment where you develop your Gears scripts, simply install 'redgrease' with pip3, as usual:
 ```
 python3 -m pip install redgrease[all]
@@ -88,22 +98,22 @@ python3 -m pip install redgrease[all]
 This installs all the dependencies, allowing for the full features set.
 
 
-`reagrease[cli]' : Installs dependencies for the cli
+`reagrease[cli]` : Installs dependencies for the CLI
 
-## Runtime Install
-A minimal install, with no 3-rd party dependencies, which is pretty much only the syntactic sugar and runtime placeholders, can be installed usig the bare 'redgrease' package. This migth be useful if you want a clean server runtime but still want the sugar.
+## Runtime / Server Enviromnment Install
+A minimal install, without any  3-rd party dependencies, which is pretty much only the syntactic sugar and runtime placeholders, can be installed usig the bare 'redgrease' package. This migth be useful if you want a clean server runtime but still want the sugar.
 
 Otherwise it is recomendede to use the `redgreese[runtime]' package as a serverside dependency. 
 This installs dependencies for the all the serverside features such as serverside Redis commands and the runtime for gears constructed with the 'Remote Gears Builder'
 
-```
+```python
 from redgrease.client import RedisGears
 
 rg = RedisGears()
-rg.gears.pyexecute("GB().run()", requirements=["redgrease[runtime]"])
+rg.gears.pyexecute("", requirements=["redgrease[runtime]"])
 ```
 
-### Redis Gears Runtime Environment
+### Note Redis Gears Runtime Environment
 The RedGrease package is NOT required to be installed in the Redis Gears Python Runtime environment, in order to run conventional Gears scripts that only use the standard commands, even if RedGrease was used for development.
 
 If you remove the redgrease import clause from your script, or wrap it in a check as outlined on the "Slightly more Advanced Usage" section, such scripts will still run perfectly fine without redgrease in Redis Gears Environment.
@@ -116,105 +126,47 @@ redis-cli RG.PYEXCUTE "$(cat yourscript.py)" REQUIRE redgrease
 ```
 Alternative you can use the RedGrease watcher or loader to automate loading your scripts as well as requirements from a normal 'requirements.txt' files, as outlined [here](https://github.com/lyngon/redgrease) 
 
-# Usage
+# Usage / Documentation
+The Documenttion is work-in-progress, but the latest and greatest version is available here: 
+## https://redgrease.readthedocs.io
 
-## Client
-Documentation is Work-in-Progress.
-Comming soon, hopefully. 
-## Builtin Runtime Functions
-You can load the default redisgears symbols (e.g. `GearsBuilder`, `GB`, `atomic`, `execute`, `log` etc) from the `redgrease.runtime` package. 
-
-During development this will give you auto-completion and type hints
-In the Redis Gears Python runtime, all the `redgrease.runtime` are mapped directly to the normal ones wihtout side-effects.
-
-```
-from redgrease import GearsBuilder, log, atomic, execute
-```
-
-This will enable auto completion in your IDE, for Redis Gears stuff. Example from Redis Gears Introduction:
-
-RedGrease's `runtime` package will detect when it is imported inside an actual RedisGears Python runtime environment and will then load the default redis gears symbols, avoiding conflict with the built-in Redis Gears Python environment.
-If it is loaded outside a Redis Gears Python runtime environment, i.e. a development environment, the `redgrease.runtime` package will instead load placeholder symbols with decent (hopefully) doc-strings and type-hints, for easier development.
-
-It is possible to load all symbols, using `*`, but it's generally not a recomended practice.
-
-
-#### Example
-Below is an ex
-```
-from redgrease.runtime import GearsBuilder, execute
-
-def age(x):
-    ''' Extracts the age from a person's record '''
-    return int(x['value']['age'])
-
-def cas(x):
-    ''' Checks and sets the current maximum '''
-    k = 'age:maximum'
-    v = execute('GET', k)   # read key's current value
-    v = int(v) if v else 0  # initialize to 0 if None
-    if x > v:               # if a new maximum found
-    execute('SET', k, x)  # set key to new value
-
-# Event handling function registration
-gb = GearsBuilder()
-gb.map(age)
-gb.foreach(cas)
-gb.register('person:*')
-
-```
-
-## Syntactic Sugar
-Documentation is Work-in-Progress.
-Comming soon, hopefully. 
-
-## Serverside Redis Commands
-Documentation is Work-in-Progress.
-Comming soon, hopefully. 
-
-## Loader CLI
-`redgrease` can be invoked from the CLI:
-```
-redgrease --help
-usage: redgrease [-h] [-c PATH] [--index-prefix PREFIX] [-r] [--script-pattern PATTERN] [--requirements-pattern PATTERN] [--unblocking-pattern PATTERN] [-i PATTERN] [-w [SECONDS]] [-s [SERVER]] [-p PORT] [-l LOG_CONFIG] dir_path [dir_path ...]
-
-Scans one or more directories for Redis Gears scripts, and executes them in a Redis Gears instance or cluster. Can optionally run continiously, montoring and re-loading scripts whenever changes are detected. Args that start with '--' (eg. --index-prefix) can also be set in a config file
-(./*.conf or /etc/redgrease/conf.d/*.conf or specified via -c). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg is specified in more than one place, then commandline values override environment variables which override
-config file values which override defaults.
-
-positional arguments:
-  dir_path              One or more directories containing Redis Gears scripts to watch
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -c PATH, --config PATH
-                        Config file path [env var: CONFIG_FILE]
-  --index-prefix PREFIX
-                        Redis key prefix added to the index of monitored/executed script files. [env var: INDEX_PREFIX]
-  -r, --recursive       Recursively watch subdirectories. [env var: RECURSIVE]
-  --script-pattern PATTERN
-                        File name pattern (glob-style) that must be matched for scripts to be loaded. [env var: SCRIPT_PATTERN]
-  --requirements-pattern PATTERN
-                        File name pattern (glob-style) that must be matched for requirement files to be loaded. [env var: REQUIREMENTS_PATTERN]
-  --unblocking-pattern PATTERN
-                        Scripts with file paths that match this regular expression, will be executed with the 'UNBLOCKING' modifier, i.e. async execution. Note that the pattern is a 'search' pattern and not anchored to thestart of the path string. [env var: UNBLOCKING_PATTERN]
-  -i PATTERN, --ignore PATTERN
-                        Ignore files matching this pattern. [env var: IGNORE]
-  -w [SECONDS], --watch [SECONDS]
-                        If set, the directories will be continously montiored for updates/modifications to scripts and requirement files, and automatically loaded/rerun. The flag takes an optional value specifying the duration, in seconds, to wait for further updates/modifications to files,
-                        before executing. This 'hysteresis' period is to prevent malformed scripts to be unnecessarily loaded during coding. If no value is supplied, the duration is defaulting to 5 seconds. [env var: WATCH]
-  -s [SERVER], --server [SERVER]
-                        Redis Gears host server IP or hostname. [env var: SERVER]
-  -p PORT, --port PORT  Redis Gears host port number [env var: PORT]
-  -l LOG_CONFIG, --log-config LOG_CONFIG
-                        [env var: LOG_CONFIG]
-```
-
-## Remote Gears
-Documentation is Work-in-Progress.
-Comming soon, hopefully. 
-
+Go read the docs!
 # Testing
-Tests are separate from the package, but are available in the GitHub repo. 
-PyTest, a number of add-ons, as well as tox, and docker is required to run the entire test suite.
-Note that tests takes excrutiatingly long as a new fresh Redis instance is spun up for each test, to ensure no risk of cross-contamination.
+Tests are separate from the package, but are available in the [GitHub repo](https://github.com/lyngon/redgrease).
+```
+git clone https://github.com/lyngon/redgrease
+``` 
+
+In order to run the tests, [Docker](https://docs.docker.com/get-docker/) is required to be installed in order to spin up fresh Redis instances, on demand for the tests. 
+
+PyTest and quite a number of its add-ons, as well as Tox, is also needed to run the tests properls. All test (and dev) requirements is best installed through:
+```
+cd redgrease/
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r src/requirements-dev.txt
+```
+Then the tess can be run with PyTest as per usual:
+```
+pytest .
+```
+Or across all supported environments (>= Python 3.6), using Tox:
+```
+tox .
+```
+
+**Note:** Running the tests takes excruciatingly long, particularly with Tox, as a new fresh Redis instance is spun up **for each test**, just to ensure no risk of cross-contamination. This may be optimized, as many tests are actually independent, but it's left like this for now.
+
+# Why This?
+The need for this arose from wanting to prototype the concepts for a new Redis module, using Gears CommandReaders and triggers instead of having to write full fledged module in C.
+
+Intitially RedGrease was just a very simple module, with placeholders for the default Redis gears runtime functiions, with type hints and docstrings, just to make it more convenient and less error prone to write Gears functions.
+
+Then the loader cli was created, in order to furthure speed up the rapid development cycle. 
+
+Then the server-side Redis 'client' commands function was addes to minimize errors (E.g. mispelled command strings).
+
+Then the client was added ... and before long it started to get a life of its own. 
+
+Note that this means RedGrease package is primarily intended to aid development of Gears scripts, and was not originally intended to be used in any "production" software. This intent has now changed, and the goal is now to make Redgrease a production grade package for Redis Gears.
+Granted, there is stilll quite some way to go to get there. 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+from typing import List
+
+# -- Project information -----------------------------------------------------
+
+project = "redgrease"
+copyright = "2021, Lyngon Pte. Ltd."
+author = "Anders Åström"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions: List[str] = []
+# ["recommonmark"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns: List[str] = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "alabaster"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,126 @@
+.. redgrease documentation master file, created by
+   sphinx-quickstart on Sat Feb 13 14:27:38 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to redgrease's documentation!
+=====================================
+
+Client
+------
+Documentation is Work-in-Progress.
+Comming soon, hopefully. 
+
+Builtin Runtime Functions
+-------------------------
+You can load the default redisgears symbols (e.g. `GearsBuilder`, `GB`, `atomic`, `execute`, `log` etc) from the `redgrease.runtime` package. 
+
+During development this will give you auto-completion and type hints
+In the Redis Gears Python runtime, all the `redgrease.runtime` are mapped directly to the normal ones wihtout side-effects.
+
+``
+from redgrease import GearsBuilder, log, atomic, execute
+``
+
+This will enable auto completion in your IDE, for Redis Gears stuff. Example from Redis Gears Introduction:
+
+RedGrease's `runtime` package will detect when it is imported inside an actual RedisGears Python runtime environment and will then load the default redis gears symbols, avoiding conflict with the built-in Redis Gears Python environment.
+If it is loaded outside a Redis Gears Python runtime environment, i.e. a development environment, the `redgrease.runtime` package will instead load placeholder symbols with decent (hopefully) doc-strings and type-hints, for easier development.
+
+It is possible to load all symbols, using `*`, but it's generally not a recomended practice.
+
+
+Example
+~~~~~~~
+Below is an ex
+``
+from redgrease.runtime import GearsBuilder, execute
+
+def age(x):
+   ''' Extracts the age from a person's record '''
+   return int(x['value']['age'])
+
+def cas(x):
+   ''' Checks and sets the current maximum '''
+   k = 'age:maximum'
+   v = execute('GET', k)   # read key's current value
+   v = int(v) if v else 0  # initialize to 0 if N
+   if x > v:               # if a new maximum found
+   execute('SET', k, x)  # set key to new value
+
+# Event handling function registration
+gb = GearsBuilder()
+gb.map(age)
+gb.foreach(cas)
+gb.register('person:*')
+
+``
+
+Syntactic Sugar
+---------------
+Documentation is Work-in-Progress.
+Comming soon, hopefully. 
+
+Serverside Redis Commands
+-------------------------
+Documentation is Work-in-Progress.
+Comming soon, hopefully. 
+
+Loader CLI
+----------
+`redgrease` can be invoked from the CLI:
+``
+redgrease --help
+usage: redgrease [-h] [-c PATH] [--index-prefix PREFIX] [-r] [--script-pattern PATTERN] [--requirements-pattern PATTERN] [--unblocking-pattern PATTERN] [-i PATTERN] [-w [SECONDS]] [-s [SERVER]] [-p PORT] [-l LOG_CONFIG] dir_path [dir_path ...]
+
+Scans one or more directories for Redis Gears scripts, and executes them in a Redis Gears instance or cluster. Can optionally run continiously, montoring and re-loading scripts whenever changes are detected. Args that start with '--' (eg. --index-prefix) can also be set in a config file
+(./*.conf or /etc/redgrease/conf.d/*.conf or specified via -c). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg is specified in more than one place, then commandline values override environment variables which override
+config file values which override defaults.
+
+positional arguments:
+   dir_path              One or more directories containing Redis Gears scripts to watch
+
+   optional arguments:
+   -h, --help            show this help message and exit
+   -c PATH, --config PATH
+                        Config file path [env var: CONFIG_FILE]
+   --index-prefix PREFIX
+                        Redis key prefix added to the index of monitored/executed script files. [env var: INDEX_PREFIX]
+   -r, --recursive       Recursively watch subdirectories. [env var: RECURSIVE]
+   --script-pattern PATTERN
+                        File name pattern (glob-style) that must be matched for scripts to be loaded. [env var: SCRIPT_PATTERN]
+   --requirements-pattern PATTERN
+                        File name pattern (glob-style) that must be matched for requirement files to be loaded. [env var: REQUIREMENTS_PATTERN]
+   --unblocking-pattern PATTERN
+                        Scripts with file paths that match this regular expression, will be executed with the 'UNBLOCKING' modifier, i.e. async execution. Note that the pattern is a 'search' pattern and not anchored to thestart of the path string. [env var: UNBLOCKING_PATTERN]
+   -i PATTERN, --ignore PATTERN
+                        Ignore files matching this pattern. [env var: IGNORE]
+   -w [SECONDS], --watch [SECONDS]
+                        If set, the directories will be continously montiored for updates/modifications to scripts and requirement files, and automatically loaded/rerun. The flag takes an optional value specifying the duration, in seconds, to wait for further updates/modifications to files,
+                        before executing. This 'hysteresis' period is to prevent malformed scripts to be unnecessarily loaded during coding. If no value is supplied, the duration is defaulting to 5 seconds. [env var: WATCH]
+   -s [SERVER], --server [SERVER]
+                        Redis Gears host server IP or hostname. [env var: SERVER]
+   -p PORT, --port PORT  Redis Gears host port number [env var: PORT]
+   -l LOG_CONFIG, --log-config LOG_CONFIG
+                        [env var: LOG_CONFIG]
+``
+
+Remote Gears
+------------
+Documentation is Work-in-Progress.
+Comming soon, hopefully. 
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for building the Documentation
+# Nothing, for now

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,8 +1,12 @@
-# TODO: Separate dev and test
 black
+isort
+sphinx==3.4.3 
+twine 
+wheel
+
 flake8
-isort[requirements_deprecated_finder]
 mypy
+
 pytest
 pytest-benchmark
 pytest-clarity
@@ -13,6 +17,5 @@ pytest-sugar
 pytest-timeout
 pytest-xdist[psutil]
 tox
-twine
-wheel
--r requirements.txt 
+
+-r requirements.txt s


### PR DESCRIPTION
# Related Issue(s):
Provide skeleton to write and publish the main documentation using sphinx and read-the-docs respectively

# Main Changes:
- ./docs directory
- ReadTheDocs stub
- Simplifed Readme.md
- Moved some nonsense (temporarily) over from Readme.md to ./docs/source/index.rst

# Additional Info
https://redgrease.readthedocs.io/en/latest/



# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relveant pytest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole pytest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [ ] Testing : Ran whole Tox test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
