### PR TITLE
Cicd

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-# Related Issue(s):
-- (specify issue here)
+# Pull Request Overview:
+- (specify any related issue here)
 
 # Main Changes:
 - (change 1)
 - (change 2)
 
-# Additionl Info
+# Additional Info
 - (additional info or context, if any)
 
 
@@ -13,14 +13,14 @@
 (Check those that apply, just so we know)
 ## Testing
 - [ ] Testing : Ad-hoc/manual
-- [ ] Testing : Ran relveant pytest's 
+- [ ] Testing : Ran releveant PyTest's 
     (I.e some test cases only)
-- [ ] Testing : Ran whole pytest suite 
+- [ ] Testing : Ran whole PyTest suite 
     (I.e. all test-cases but for one or limited number of environments)
-- [ ] Testing : Ran whole nox test suite 
-    (I.e. all test-casese across all supported environments)
+- [ ] Testing : Ran whole Tox test suite 
+    (I.e. all test-cases across all supported environments)
   
 ## Documentation
 - [ ] Documentation : Type Hints
-- [ ] Documentation : Doc-Strigns
+- [ ] Documentation : Doc-Strings
 - [ ] Documentation : Usage Guide / Manual

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,36 @@
-sudo: false
 language: python
-matrix:
-  include:
-    - python: 3.6
-      env: TOXENV=py36
-    - python: 3.7
-      env: TOXENV=py37
-    - python: 3.8
-      env: TOXENV=py38
-    - python: 3.9
-      env: TOXENV=py39
-#    - python: pypy
-#      env: TOXENV=pypy
-    - env: TOXENV=flake8
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+install:
+  - pip install -r src/requirements-test.txt
+  - pip install .
 services:
   - docker
 before_install:
   - docker pull redislabs/redisgears
-install: pip install tox-travis
-script: tox
+script:
+  - pytest
+
+# sudo: false
+# language: python
+# matrix:
+#   include:
+#     - python: 3.6
+#       env: TOXENV=py36
+#     - python: 3.7
+#       env: TOXENV=py37
+#     - python: 3.8
+#       env: TOXENV=py38
+#     - python: 3.9
+#       env: TOXENV=py39
+# #    - python: pypy3
+# #      env: TOXENV=pypy3
+# services:
+#   - docker
+# before_install:
+#   - docker pull redislabs/redisgears
+# install: pip install tox-travis
+# script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - docker pull redislabs/redisgears
 script:
   - pytest
+after_success:
+  - codecov
+
 
 # sudo: false
 # language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 sudo: false
 language: python
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-    - "3.9"
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
+#    - python: pypy
+#      env: TOXENV=pypy
+    - env: TOXENV=flake8
 services:
   - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: python
+python:
+    - "3.6"
+    - "3.7"
+    - "3.8"
+    - "3.9"
+services:
+  - docker
+before_install:
+  - docker pull redislabs/redisgears
+install: pip install tox-travis
+script: tox

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -3,21 +3,6 @@ isort
 sphinx==3.4.3 
 twine 
 wheel
-
-flake8
 mypy
 
-codecov
-importlib-metadata
-pytest
-pytest-benchmark
-pytest-clarity
-pytest-cov
-pytest-datafiles
-pytest-docker-tools
-pytest-sugar
-pytest-timeout
-pytest-xdist[psutil]
-tox
-
--r requirements.txt s
+-r requirements-test.txt s

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -10,6 +10,6 @@ pytest-docker-tools
 pytest-sugar
 pytest-timeout
 pytest-xdist[psutil]
-tox
+# tox
 
 -r requirements.txt s

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -1,15 +1,15 @@
 codecov
 flake8
 importlib-metadata
-pytest
+pytest==6.0.1
 pytest-benchmark
 pytest-clarity
-pytest-cov
+pytest-cov==2.10.1
 pytest-datafiles
 pytest-docker-tools
 pytest-sugar
 pytest-timeout
-pytest-xdist[psutil]
+pytest-xdist[psutil]==2.0.0
 # tox
 
 -r requirements.txt s

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -1,0 +1,15 @@
+codecov
+flake8
+importlib-metadata
+pytest
+pytest-benchmark
+pytest-clarity
+pytest-cov
+pytest-datafiles
+pytest-docker-tools
+pytest-sugar
+pytest-timeout
+pytest-xdist[psutil]
+tox
+
+-r requirements.txt s

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 attrs
 ConfigArgParse
+dataclasses  # for python 3.6 compatibility only
 pyyaml
 redis
 watchdog

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ warn_unreachable = True
 
 [tox]
 envlist = 
-    {1.0.0,latest}-py{36,37,38,39}
+    py{36,37,38,39}
+#   {1.0.0,latest}-py{36,37,38,39}
 #   {1.0.0,latest}-pypy3 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ envlist =
 passenv = CI TRAVIS TRAVIS_*
 changedir = tests
 deps =
-    -rsrc/requirements-dev.txt
+    -rsrc/requirements-test.txt
 # allowlist_externals = ...
 # commands_pre = ....
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -45,22 +45,31 @@ warn_redundant_casts = True
 warn_unused_configs = True
 warn_unreachable = True
 
-[tox]
-envlist = 
-    py{36,37,38,39}
-#   {1.0.0,latest}-py{36,37,38,39}
-#   {1.0.0,latest}-pypy3 
+; [tox]
+; envlist = 
+;     py{36,37,38,39}
+; #   {1.0.0,latest}-py{36,37,38,39}
+; #   {1.0.0,latest}-pypy3 
 
-[testenv]
-passenv = CI TRAVIS TRAVIS_*
-changedir = tests
-deps =
-    -rsrc/requirements-test.txt
-# allowlist_externals = ...
-# commands_pre = ....
-commands = 
-    pip install {toxinidir}
-    # Note: May want to use '--dist loadscopes' to pallelize on scope level?
-    pytest --basetemp="{envtmpdir}" --cov-report=xml --cov=redgrease -n auto -vv {posargs}
-    codecov
-# commands_post = ...
+; [testenv]
+; passenv = CI TRAVIS TRAVIS_*
+; changedir = tests
+; deps =
+;     -rsrc/requirements-test.txt
+; # allowlist_externals = ...
+; # commands_pre = ....
+; commands = 
+;     pip install {toxinidir}
+;     # Note: May want to use '--dist loadscopes' to pallelize on scope level?
+;     pytest --basetemp="{envtmpdir}" --cov-report=xml --cov=redgrease -n auto -vv {posargs}
+;     codecov
+; # commands_post = ...
+
+[pytest]
+testpaths =
+    tests
+addopts =
+    --cov=redgrease 
+    --cov-report=xml 
+    -n auto
+    -vv


### PR DESCRIPTION
Remove Tox completely (save the name of the tox.ini file that could be merged with the setup.cfg, if this works)

# Main Changes:
- away with tox
- all environments tested using Travis instead
- added 'dataclasses' as a requirement, backport for py36, that does not have it native

# Additionl Info
None


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relveant pytest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole pytest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [ ] Testing : Ran whole nox test suite 
    (I.e. all test-casese across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strigns
- [ ] Documentation : Usage Guide / Manual
