### PR TITLE
Modules refactoring

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,11 +1,5 @@
-from typing import Callable, Dict
-
 import redgrease
-import redgrease.client
-import redgrease.reader
-import redgrease.runtime
 import redgrease.utils
-from redgrease.typing import Constructor
 
 mapping = {
     "active": bool,
@@ -13,8 +7,8 @@ mapping = {
 }
 
 
-def hash_to_dict(mapping: Dict[str, Constructor]) -> Callable[[str], Dict]:
-    def parser(hash_key: str) -> Dict:
+def hash_to_dict(mapping):
+    def parser(hash_key: str):
         vals = redgrease.cmd.hmget(hash_key, mapping.keys())
         return redgrease.utils.dict_of(mapping)(vals, mapping.keys())
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,27 +1,22 @@
 import redgrease
 import redgrease.utils
 
-mapping = {
+user_structure = {
     "active": bool,
     "permissions": redgrease.utils.list_parser(str),
 }
 
-
-def hash_to_dict(mapping):
-    def parser(hash_key: str):
-        vals = redgrease.cmd.hmget(hash_key, mapping.keys())
-        return redgrease.utils.dict_of(mapping)(vals, mapping.keys())
-
-    return parser
-
-
 # Partial Gear function, w. default run param:
 active_users = (
-    redgrease.reader.KeysOnlyReader("user:*")
-    .map(hash_to_dict(mapping))
+    redgrease.KeysOnlyReader("user:*")
+    .map(lambda key: redgrease.cmd.hmget(key, *user_structure.keys()))
+    .map(
+        lambda udata: redgrease.utils.to_dict(
+            udata, keys=user_structure.keys(), val_transform=user_structure
+        )
+    )
     .filter(lambda usr: usr["active"])
 )
-
 # Partial Gear function re-use:
 active_user_count = active_users.count()
 
@@ -29,20 +24,15 @@ all_issued_permissions = active_users.flatmap(lambda usr: usr["permissions"]).di
 
 # Redis Client w. Gears
 r = redgrease.client.RedisGears()
-for usr_id in range(100):
-    r.hset(
-        f"user:{usr_id}",
-        mapping={
-            "name": f"mr {usr_id}",
-            "id": usr_id,
-            "active": int(bool(usr_id % 3)),
-            "permissions": str(["eat", "sleep"]),
-        },
-    )
 
 # Two ways of running:
 count = r.gears.pyexecute(active_user_count.run())
 permissions = all_issued_permissions.run().on(r)
 
-print(f"Count: {count.results[0]}")
+print(f"Count: {count.results}")
+if count.errors:
+    print(count.errors)
+
 print(f"Permissions: {permissions.results}")
+if permissions.errors:
+    print(permissions.errors)

--- a/examples/mock_data.py
+++ b/examples/mock_data.py
@@ -1,0 +1,19 @@
+import redis
+
+
+def load_users(server: redis.Redis, count=100):
+    for usr_id in range(count):
+        server.hset(
+            f"user:{usr_id}",
+            mapping={
+                "name": f"mr {usr_id}",
+                "id": usr_id,
+                "active": int(bool(usr_id % 3)),
+                "permissions": str(["eat", "sleep"]),
+            },
+        )
+
+
+r = redis.Redis()
+
+load_users(r, 200)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.1.6
+version = 0.1.7.dev1
 license_files = LICENSE
 
 [tool.black]

--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -1,30 +1,74 @@
-__all__ = []
-
 import sys
 
-from .sugar import FailurePolicy as FailurePolicy
-from .sugar import KeyType as KeyType
-from .sugar import LogLevel as LogLevel
-from .sugar import Reader as Reader
-from .sugar import TriggerMode as TriggerMode
+from .func import trigger as trigger
+from .gears import ClosedGearFunction, GearFunction, PartialGearFunction
+from .requirements import read_requirements
+from .sugar import FailurePolicy, KeyType, LogLevel, ReaderType, TriggerMode
 
-__all__ += [
+__all__ = [
+    "trigger",
+    "ClosedGearFunction",
+    "GearFunction",
+    "PartialGearFunction",
+    "read_requirements",
     "FailurePolicy",
     "KeyType",
     "LogLevel",
-    "Reader",
+    "ReaderType",
     "TriggerMode",
+    "utils",
+    "typing",
 ]
 
-# Note: the form "from ... import x as x" is used not to trigger the mypy error
-# "implicit reexport", as described here:
-# https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport
+# Dynamic / Conditional imports below. (depends on installed packa)
+
+try:
+    # This will fail if redis package is not installed
+    from .client import Gears, Redis, RedisGears
+
+    __all__ += ["Gears", "Redis", "RedisGears"]
+except ModuleNotFoundError:
+    pass
 
 try:
     # This will fail if redis package is not installed
     from .command import redis as cmd
 
     __all__ += ["cmd"]
+except ModuleNotFoundError:
+    pass
+
+
+try:
+    # this will fail if either redis, watchdog or pyaml packages are not installed
+    from .loader import GearsLoader
+
+    __all__ += ["GearsLoader"]
+except ModuleNotFoundError:
+    pass
+
+
+try:
+    # this will fail if either redis or packaging packages are not installed
+    from .reader import (
+        CommandReader,
+        GearReader,
+        KeysOnlyReader,
+        KeysReader,
+        PythonReader,
+        ShardsIDReader,
+        StreamReader,
+    )
+
+    __all__ += [
+        "CommandReader",
+        "GearReader",
+        "KeysOnlyReader",
+        "KeysReader",
+        "PythonReader",
+        "ShardsIDReader",
+        "StreamReader",
+    ]
 except ModuleNotFoundError:
     pass
 
@@ -47,14 +91,16 @@ if "redisgears" in sys.modules:
 else:
     # Dev or Client environment
     # Import placeholder functions and
-    from .runtime import GB as GB
-    from .runtime import GearsBuilder as GearsBuilder
-    from .runtime import atomic as atomic
-    from .runtime import configGet as configGet
-    from .runtime import execute as execute
-    from .runtime import gearsConfigGet as gearsConfigGet
-    from .runtime import hashtag as hashtag
-    from .runtime import log as log
+    from .runtime import (
+        GB,
+        GearsBuilder,
+        atomic,
+        configGet,
+        execute,
+        gearsConfigGet,
+        hashtag,
+        log,
+    )
 
 __all__ += [
     "GB",

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -21,29 +21,6 @@ from redgrease.utils import (
 log = logging.getLogger(__name__)
 
 
-# """import cloudpickle
-# try:
-#     log("Got Gear")
-#     cloudpickle.loads({cloudpickle.dumps(gear_function, protocol=4)}).compile(GB)
-# except Exception as err:
-#     log(str(err))
-#     import sys
-#     def pystr(pyver):
-#         return "Python %s.%s" % pyver
-#     runtime_version = sys.version_info[:2]
-#     function_version = {sys.version_info[:2]}
-#     if runtime_version != function_version:
-#         raise SystemError(
-#             "%s runtime cannot execute Gears functions created in %s. %s" % (
-#                 pystr(runtime_version),
-#                 pystr(function_version),
-#                 "Only matching Python versions are supported"
-#             )
-#         ) from err
-#     raise
-# """
-
-
 class Gears:
     def __init__(self, redis):
         self.redis = redis

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -295,19 +295,19 @@ class GearFunction(Generic[T]):
     @property
     def supports_batch_mode(self):
         return self.reader in [
-            sugar.Reader.KeysReader,
-            sugar.Reader.KeysOnlyReader,
-            sugar.Reader.StreamReader,
-            sugar.Reader.PythonReader,
-            sugar.Reader.ShardsIDReader,
+            sugar.ReaderType.KeysReader,
+            sugar.ReaderType.KeysOnlyReader,
+            sugar.ReaderType.StreamReader,
+            sugar.ReaderType.PythonReader,
+            sugar.ReaderType.ShardsIDReader,
         ]
 
     @property
     def supports_event_mode(self):
         return self.reader in [
-            sugar.Reader.KeysReader,
-            sugar.Reader.StreamReader,
-            sugar.Reader.CommandReader,
+            sugar.ReaderType.KeysReader,
+            sugar.ReaderType.StreamReader,
+            sugar.ReaderType.CommandReader,
         ]
 
 

--- a/src/redgrease/loader.py
+++ b/src/redgrease/loader.py
@@ -241,7 +241,9 @@ class GearsLoader:
         """
         log.debug(f"Updating dependecies as per '{requirements_file_path}'")
         try:
-            requirements_list = list(requirements.read(requirements_file_path))
+            requirements_list = list(
+                requirements.read_requirements(requirements_file_path)
+            )
             log.debug(f"Requirements to load: {', '.join(requirements_list)}")
             self.redis.gears.pyexecute("GB().run()", requirements=requirements_list)
         except Exception as ex:

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -74,7 +74,7 @@ class KeysReader(GearReader):
         default_key_pattern: str = "*",
     ):
         super().__init__(
-            reader=redgrease.sugar.Reader.KeysReader, defaultArg=default_key_pattern
+            reader=redgrease.sugar.ReaderType.KeysReader, defaultArg=default_key_pattern
         )
         self.default_key_pattern = default_key_pattern
 
@@ -85,7 +85,8 @@ class KeysOnlyReader(GearReader):
         default_key_pattern: str = "*",
     ):
         super().__init__(
-            reader=redgrease.sugar.Reader.KeysOnlyReader, defaultArg=default_key_pattern
+            reader=redgrease.sugar.ReaderType.KeysOnlyReader,
+            defaultArg=default_key_pattern,
         )
         self.default_key_pattern = default_key_pattern
 
@@ -96,21 +97,22 @@ class StreamReader(GearReader):
         default_key_pattern: str = "*",
     ):
         super().__init__(
-            reader=redgrease.sugar.Reader.StreamReader, defaultArg=default_key_pattern
+            reader=redgrease.sugar.ReaderType.StreamReader,
+            defaultArg=default_key_pattern,
         )
         self.default_key_pattern = default_key_pattern
 
 
 class PythonReader(GearReader):
     def __init__(self):
-        super().__init__(reader=redgrease.sugar.Reader.PythonReader)
+        super().__init__(reader=redgrease.sugar.ReaderType.PythonReader)
 
 
 class ShardsIDReader(GearReader):
     def __init__(self):
-        super().__init__(reader=redgrease.sugar.Reader.ShardsIDReader)
+        super().__init__(reader=redgrease.sugar.ReaderType.ShardsIDReader)
 
 
 class CommandReader(GearReader):
     def __init__(self):
-        super().__init__(reader=redgrease.sugar.Reader.CommandReader)
+        super().__init__(reader=redgrease.sugar.ReaderType.CommandReader)

--- a/src/redgrease/requirements.py
+++ b/src/redgrease/requirements.py
@@ -3,7 +3,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def read(*requirements_file_paths: str):
+def read_requirements(*requirements_file_paths: str):
     """Extract list of individual requirements from a 'requirements.txt' file
 
     Args:

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class GearsBuilder(redgrease.gears.PartialGearFunction):
     def __init__(
         self,
-        reader: str = sugar.Reader.KeysReader,
+        reader: str = sugar.ReaderType.KeysReader,
         defaultArg: str = "*",
         desc: str = None,
     ):

--- a/src/redgrease/sugar.py
+++ b/src/redgrease/sugar.py
@@ -5,7 +5,7 @@ import logging
 # - Function decorators for boilerplate gears constructs
 
 
-class Reader:
+class ReaderType:
     """Redis Gears Reader Types"""
 
     KeysReader = "KeysReader"

--- a/src/redgrease/utils.py
+++ b/src/redgrease/utils.py
@@ -292,6 +292,7 @@ def transform(
 
 def to_dict(
     items: Iterable,
+    keys: Iterable = None,
     key_transform: Union[Constructor[Key], Dict[Any, Constructor[Key]]] = None,
     val_transform: Union[Constructor[Val], Dict[Key, Constructor[Val]]] = None,
 ) -> Dict[Key, Val]:
@@ -344,9 +345,14 @@ def to_dict(
     if val_transform is None:
         val_transform = as_is
 
-    it = iter(items)
+    if keys:
+        kv_pairs = zip(keys, items)
+    else:
+        it = iter(items)
+        kv_pairs = zip(it, it)
+
     result = {}
-    for key, value in zip(it, it):
+    for key, value in kv_pairs:
         key = transform(key, key_transform, key)
         value = transform(value, val_transform, key)  # type: ignore
         result[key] = value

--- a/tests/gear_scripts/redgrease_runtime_redis_api_get_set.py
+++ b/tests/gear_scripts/redgrease_runtime_redis_api_get_set.py
@@ -29,4 +29,4 @@ def double(record):
         redgrease.cmd.set(key, val)
 
 
-redgrease.GB(redgrease.Reader.KeysReader).foreach(double).run()
+redgrease.GB(redgrease.ReaderType.KeysReader).foreach(double).run()


### PR DESCRIPTION
# Pull Request Overview:
- Better exports and working example

# Main Changes:
- Top level exports of all module symbols that makes sense for most users. I.e 'redgrease.gears.GearFunction' is now also exposed as 'redgrease.GearFunction'. Modules that repent on third party extras are exposed only if successfully loaded. Modules that are not intended for users to invoke, e.g 'redgrease.data' and 'redgrease.config' are excluded. Also 'redgrease.utils' and 'redgrease.typing' are excluded, despite being intended for users (due to number of symbols) 

- basic example is more concise. 

- generalized to_dict to also take non-interlaced lists as input, provided that the keys are provided through a new argument

- renamed 'sugar.Reader'  to 'sugar.ReaderType' not to be too confusing with the actual readers in 'reader' module

- renamed 'requirements.read' to 'requirements.read_requirements' so that it could be exposed top level and still make sense. 

- added as dummy data loader to the examples.

# Additional Info
None


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [H] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite  **Note: Need to add tests for the new *'to_dict'* functionality**
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
