### PR TITLE
Updated Execution result

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.1.7.dev1
+version = 0.1.7
 license_files = LICENSE
 
 [tool.black]

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -299,7 +299,7 @@ class Redis(redis.Redis):
             "RG.PYSTATS": redgrease.data.PyStats.from_redis,
             "RG.PYDUMPREQS": list_parser(redgrease.data.PyRequirementInfo.from_redis),
             "RG.REFRESHCLUSTER": bool_ok,
-            "RG.TRIGGER": as_is,
+            "RG.TRIGGER": redgrease.data.Execution,
             "RG.UNREGISTER": bool_ok,
         },
     }

--- a/src/redgrease/utils.py
+++ b/src/redgrease/utils.py
@@ -1,3 +1,4 @@
+import functools
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -209,6 +210,14 @@ def to_redis_type(value: Any) -> RedisType:
         return value
 
     return to_redis_type(str(value))
+
+
+def to_bytes(value: Any) -> bytes:
+    compat_val = to_redis_type(value)
+    if isinstance(compat_val, bytes):
+        return compat_val
+    else:
+        return str(compat_val).encode()
 
 
 # Not a parser
@@ -475,3 +484,7 @@ def record(rec: Union[str, dict]) -> Record:
 
     if isinstance(rec, str):
         return Record(rec)
+
+
+def compose(*functions):
+    return functools.reduce(lambda f, g: lambda x: f(g(x)), functions, lambda x: x)

--- a/temp/test_stuff.py
+++ b/temp/test_stuff.py
@@ -1,0 +1,95 @@
+from typing import Any, List, Optional
+
+from redgrease.utils import to_bytes
+
+# import attr
+
+
+# @attr.s(auto_attribs=True, frozen=True)
+class Execution:
+    def __init__(self, result: Any, errors: Optional[List] = None):
+        self.result = result
+        self.errors = errors
+
+    def __bool__(self) -> bool:
+        if self.errors:
+            return False
+        else:
+            return bool(self.result)
+
+    def __iter__(self):
+        try:
+            return iter(self.result)
+        except (TypeError, AttributeError):
+            return iter([] if self.result is None else [self.result])
+
+    def __len__(self) -> int:
+        try:
+            return len(self.result)
+        except (TypeError, AttributeError):
+            return 0 if self.result is None else 1
+
+    def __getitem__(self, *args, **kwargs):
+        try:
+            return self.result.__getitem__(*args, **kwargs)
+        except (TypeError, AttributeError):
+            if args and args[0] == 0:
+                return self.result
+            raise
+
+    def __contains__(self, val) -> bool:
+        try:
+            return self.result.__contains__(val)
+        except (TypeError, AttributeError):
+            return val == self.result
+
+    def __bytes__(self):
+        return to_bytes(self.result)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Execution):
+            return self.result == other.result and self.errors == other.errors
+
+        if self.errors:
+            return False
+
+        return self.result == other
+
+    def __repr__(self) -> str:
+        if self.errors:
+            return f"{self.__class__.__name__}({self.result}, errors={self.errors})"
+        else:
+            return f"{self.__class__.__name__}({self.result})"
+
+    def __str__(self) -> str:
+        return repr(self)
+
+
+e1 = Execution(True)
+e2 = Execution(["a", "o", "b"], ["Oh noes!"])
+e3 = Execution(False)
+e4 = Execution("Anders Astrom")
+e5 = Execution(list(range(20)), ["meh"])
+e6 = Execution([False, True])
+
+for ex in [e1, e2, e3, e4, e5, e6]:
+    print("====")
+    print(ex)
+    print(f"it is {bool(ex)}")
+    print(f"it has length {len(ex)}")
+    print(f"the first element is {ex[0]}")
+    for res in ex:
+        print(f"{res}")
+    try:
+        print(f"...have a slice: {ex[1:-1]}")
+    except Exception:
+        print("not sliceable")
+    for i in [True, "o", 3]:
+        print(f"{i} is{' ' if i in ex else ' NOT '}inside")
+    try:
+        print(f"bytes version: {bytes(ex)}")  # type: ignore
+    except Exception:
+        print("no byte allowed")
+
+    for i in [True, "Anders Astrom", ["a", "o", "b"]]:
+        print(f"it is{' ' if i == ex else ' NOT '}equal to {i}")

--- a/tests/test_builtin_runtime_functions.py
+++ b/tests/test_builtin_runtime_functions.py
@@ -91,8 +91,9 @@ def test_builtin_runtime_functions(
     while not rg.ping():
         time.sleep(1)
 
-    assert rg.gears.pyexecute(
-        "", requirements=[f"redgrease{extras}=={redgrease_version}"]
+    assert (
+        rg.gears.pyexecute("", requirements=[f"redgrease{extras}=={redgrease_version}"])
+        is not None
     )
 
     _, contents = gears_script
@@ -116,7 +117,7 @@ def test_builtin_runtime_functions(
 
     result = rg.gears.pyexecute(script_str)
 
-    assert result
+    assert result is not None
     assert isinstance(result, redgrease.data.Execution)
     assert not result.errors
 
@@ -133,8 +134,8 @@ GB().run()
         # With any of the extras installed, it should be
         # possibleto run gears that import both
         # 'redgrease.command' as well as 'redis'
-        assert rg.gears.pyexecute(runtime_extras_import)
-        assert rg.gears.pyexecute(redis_import)
+        assert rg.gears.pyexecute(runtime_extras_import) is not None
+        assert rg.gears.pyexecute(redis_import) is not None
     else:
         # If no redgrease extras are installed,
         # then we should not be able to import nither

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,7 +37,7 @@ def test_pydumpreqs(rg: RedisGears, package):
 
     if package not in preexisting:
         # Add a requirement for package
-        assert rg.gears.pyexecute("", requirements=[package]) is True
+        assert rg.gears.pyexecute("", requirements=[package])
 
         new_reqs = rg.gears.pydumpreqs()
 
@@ -60,8 +60,8 @@ def test_trigger(rg: RedisGears, arg_list: List, mode: str):
     )
     assert rg.gears.pyexecute(fun_str, unblocking=unblocking)
     res = rg.gears.trigger(triggger_name, *arg_list)
-    assert res
-    assert isinstance(res, list)
+    assert isinstance(res, redgrease.data.Execution)
+    assert isinstance(res.result, list)
     assert len(res) == len(arg_list) + 1
     # For some reason flatmap seems to reverse the order
     str_res = list(map(safe_str, res))
@@ -166,19 +166,19 @@ def test_getexecution(rg: RedisGears, fun_str: str):
     exec = rg.gears.pyexecute(fun_str, unblocking=True)
     assert exec
     assert isinstance(exec, redgrease.data.Execution)
-    assert exec.results
+    assert exec.result
     assert not exec.errors
-    assert isinstance(exec.results, redgrease.data.ExecID)
-    shard_id = exec.results.shard_id
+    assert isinstance(exec.result, redgrease.data.ExecID)
+    shard_id = exec.result.shard_id
 
     # ! Possibly a race condition that executon is not complete. Ugly AF sln.
     time.sleep(5)
 
-    res = rg.gears.getexecution(exec.results)  # TODO: This is an odd API syntax
+    res = rg.gears.getexecution(exec.result)  # TODO: This is an odd API syntax
     assert res
     assert isinstance(res, dict)
     assert shard_id in res.keys()
-    exe_plan = res[exec.results.shard_id]  # TODO: Real awkward
+    exe_plan = res[exec.result.shard_id]  # TODO: Real awkward
     assert exe_plan
     assert isinstance(exe_plan, redgrease.data.ExecutionPlan)
     assert exe_plan.status
@@ -210,16 +210,16 @@ def test_getresults(rg: RedisGears):
     fun_str = """GB().count().run()"""
 
     exec = rg.gears.pyexecute(fun_str, unblocking=True)
-    assert exec
+    assert exec is not None
     assert isinstance(exec, redgrease.data.Execution)
-    assert exec.results
+    assert exec.result
     assert not exec.errors
-    assert isinstance(exec.results, redgrease.data.ExecID)
+    assert isinstance(exec.result, redgrease.data.ExecID)
 
     # ! Possibly a race condition that executon is not complete. Ugly AF sln.
     time.sleep(5)
 
-    res = rg.gears.getresults(exec.results)  # TODO: is this how we want it to work?
+    res = rg.gears.getresults(exec.result)  # TODO: is this how we want it to work?
     assert res
     assert isinstance(
         res, list

--- a/tests/test_prog_gears.py
+++ b/tests/test_prog_gears.py
@@ -24,7 +24,7 @@ def test_map(rg):
 
     gear_fun = GearsBuilder().map(lambda x: x["value"]).sort().run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["1", "2", "3"]
+    assert res.result == ["1", "2", "3"]
     assert res.errors == []
 
 
@@ -39,7 +39,7 @@ def test_filter(rg: RedisGears):
     rg.set("z", "3")
     gear_fun = GearsBuilder().map(lambda x: x["value"]).filter(lambda x: x == "1").run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["1"]
+    assert res.result == ["1"]
     assert res.errors == []
 
 
@@ -62,7 +62,7 @@ def test_foreach(rg: RedisGears):
     gear_fun = GearsBuilder().foreach(increase).map(lambda _: counter).run()
 
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [1, 2, 3]
+    assert res.result == [1, 2, 3]
     assert res.errors == []
 
 
@@ -81,7 +81,7 @@ def test_flatmap(rg: RedisGears):
         .run()
     )
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["1", "2", "3"]
+    assert res.result == ["1", "2", "3"]
     assert res.errors == []
 
 
@@ -104,7 +104,7 @@ def test_countby(rg: RedisGears):
         .run()
     )
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [("1", 2), ("2", 2)]
+    assert res.result == [("1", 2), ("2", 2)]
     assert res.errors == []
 
 
@@ -120,7 +120,7 @@ def test_avg(rg: RedisGears):
     rg.set("t", "2")
     gear_fun = GearsBuilder().map(lambda x: x["value"]).avg().run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [1.5]
+    assert res.result == [1.5]
     assert res.errors == []
 
 
@@ -136,7 +136,7 @@ def test_count(rg: RedisGears):
     rg.set("t", "2")
     gear_fun = GearsBuilder().count().run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [4]
+    assert res.result == [4]
     assert res.errors == []
 
 
@@ -152,7 +152,7 @@ def test_distinct(rg: RedisGears):
     rg.set("t", "2")
     gear_fun = GearsBuilder().map(lambda x: x["value"]).distinct().count().run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [2]
+    assert res.result == [2]
     assert res.errors == []
 
 
@@ -173,7 +173,7 @@ def test_aggregate(rg: RedisGears):
         .run()
     )
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [6]
+    assert res.result == [6]
     assert res.errors == []
 
 
@@ -196,7 +196,7 @@ def test_aggregateby(rg: RedisGears):
         .run()
     )
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == [("1", 2), ("2", 4)]
+    assert res.result == [("1", 2), ("2", 4)]
     assert res.errors == []
 
 
@@ -212,7 +212,7 @@ def test_limit(rg: RedisGears):
     rg.set("t", "2")
     gear_fun = GearsBuilder().map(lambda x: x["value"]).sort().limit(1).run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["1"]
+    assert res.result == ["1"]
     assert res.errors == []
 
 
@@ -228,7 +228,7 @@ def test_sort(rg: RedisGears):
     rg.set("t", "2")
     gear_fun = GearsBuilder().map(lambda x: x["key"]).sort().run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["t", "x", "y", "z"]
+    assert res.result == ["t", "x", "y", "z"]
     assert res.errors == []
 
 
@@ -240,7 +240,7 @@ def test_sort(rg: RedisGears):
 def test_hashtag(rg: RedisGears):
     gear_fun = GearsBuilder("ShardsIDReader").map(lambda _: hashtag()).run()
     res = rg.gears.pyexecute(gear_fun)
-    assert res.results == ["06S"]
+    assert res.result == ["06S"]
     assert res.errors == []
 
 
@@ -252,7 +252,7 @@ def test_hashtag(rg: RedisGears):
 def test_register(rg: RedisGears):
     gear_fun = GearsBuilder("CommandReader").register(trigger="test")
     res = rg.gears.pyexecute(gear_fun)
-    assert res is True
+    assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
     print(res)

--- a/tests/test_runtime_redis_api.py
+++ b/tests/test_runtime_redis_api.py
@@ -33,8 +33,8 @@ def test_basic(rg: RedisGears, script):
     script_name, script_contents = script
     # First set no keys
     res_0 = rg.gears.pyexecute(script_contents)
-    assert res_0
-    assert res_0.results == []
+    assert res_0 is not None
+    assert res_0.result == []
 
     orig_val = 13
     key = "NUM"
@@ -42,8 +42,8 @@ def test_basic(rg: RedisGears, script):
     assert rg.set(key, orig_val)
 
     res_1 = rg.gears.pyexecute(script_contents)
-    assert res_1
-    assert res_1.results
+    assert res_1 is not None
+    assert res_1.result
     assert res_1.errors == []
 
     assert float(safe_str(rg.get(key))) == orig_val * 2


### PR DESCRIPTION
# Pull Request Overview:
Slightly better result type for `pyexecute`. now always of type `Execution` regardless of how `pyexecute` is invoked


# Main Changes:
- new Execution class, that wraps all result types from `pyexecute`
- Execution object is always returned for both `pyexecute` and `trigger`
- Execution object behaves (almost) like the result it wraps, unless there are errors. Errors makes it 'Falsey'
- Execution behaves like a list of its result, even if is a singular value

 
# Additional Info
Not really


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [ ] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
