### PR TITLE
Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ def process(x):
 gear = CommandReader().flatmap(as_is).map(process).register(trigger="launch")
 
 # Redis client with Gears
-rg = RedisGears()
+rg = redgrease.RedisGears()
 
 # Register the gear function on a cluster
 gear.on(rg) 
@@ -204,9 +204,9 @@ It is recomendede to use the `redgreese[runtime]` package as a serverside depend
 This installs dependencies for the all the serverside features such as serverside Redis commands and the runtime for gears constructed with the 'Remote Gears Builder'
 
 ```python
-from redgrease.client import RedisGears
+import redgrease
 
-rg = RedisGears()
+rg = redgrease.RedisGears()
 rg.gears.pyexecute("", requirements=["redgrease[runtime]"])
 ```
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -23,7 +23,7 @@ active_user_count = active_users.count()
 all_issued_permissions = active_users.flatmap(lambda usr: usr["permissions"]).distinct()
 
 # Redis Client w. Gears
-r = redgrease.client.RedisGears()
+r = redgrease.RedisGears()
 
 # Two ways of running:
 count = r.gears.pyexecute(active_user_count.run())

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ common_extras = [
 runtime_extras = common_extras + []
 client_extras = common_extras + [
     "typing-extensions",
+    
 ]
 cli_extras = client_extras + [
     "watchdog",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ common_extras = [
 runtime_extras = common_extras + []
 client_extras = common_extras + [
     "typing-extensions",
-    
+    "redis-py-cluster",
 ]
 cli_extras = client_extras + [
     "watchdog",

--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -77,9 +77,11 @@ try:
         # This will fail if redis-py-cluster package is not installed
         from .cluster import RedisCluster, RedisGears
 
-        __all__ += ["RedisGears", "RedisCluster"]
+        __all__ += ["RedisCluster"]
     except ModuleNotFoundError:
         from .client import Redis as RedisGears
+
+    __all__ += ["RedisGears"]
 
 except ModuleNotFoundError:
     pass

--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -69,15 +69,25 @@ __all__ = [
 
 try:
     # This will fail if redis package is not installed
-    from .client import Gears, Redis, RedisCluster, RedisGears, geared
+    from .client import Gears, Redis, geared
 
-    __all__ += ["Gears", "Redis", "RedisCluster", "RedisGears", "geared"]
+    __all__ += ["Gears", "Redis", "geared"]
+
+    try:
+        # This will fail if redis-py-cluster package is not installed
+        from .cluster import RedisCluster, RedisGears
+
+        __all__ += ["RedisGears", "RedisCluster"]
+    except ModuleNotFoundError:
+        from .client import Redis as RedisGears
+
 except ModuleNotFoundError:
     pass
 
+
 try:
     # This will fail if redis package is not installed
-    from .command import redis as cmd
+    from .command import cmd
 
     __all__ += ["cmd"]
 except ModuleNotFoundError:

--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -69,9 +69,9 @@ __all__ = [
 
 try:
     # This will fail if redis package is not installed
-    from .client import Gears, Redis, RedisGears
+    from .client import Gears, Redis, RedisCluster, RedisGears, geared
 
-    __all__ += ["Gears", "Redis", "RedisGears"]
+    __all__ += ["Gears", "Redis", "RedisCluster", "RedisGears", "geared"]
 except ModuleNotFoundError:
     pass
 

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -51,7 +51,6 @@ import os.path
 from typing import Any, Iterable, List, Mapping, Optional, Union
 
 import redis
-import rediscluster
 
 import redgrease.config
 import redgrease.data
@@ -502,28 +501,3 @@ class Redis(redis.Redis):
     def __init__(self, *args, **kwargs):
         """Instantiate a redis client, with gears features"""
         super().__init__(*args, **kwargs)
-
-
-@geared
-class RedisCluster(rediscluster.RedisCluster):
-    """RedisCluster client class, with support for gears features
-
-    Behaves exactly like the rediscluster.RedisCluster client, but is extended with
-    a 'gears' property fo executiong Gears commands.
-
-    Attributes:
-        gears (redgrease.client.Gears):
-            Gears command client.
-    """
-
-    def __init__(self, *args, **kwargs):
-        """Instantiate a redis cluster client, with gears features"""
-
-        super().__init__(*args, **kwargs)
-
-
-def RedisGears(*args, **kwargs):
-    try:
-        return RedisCluster(*args, **kwargs)
-    except rediscluster.exceptions.RedisClusterException:
-        return Redis(*args, **kwargs)

--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -1,0 +1,29 @@
+import rediscluster
+import rediscluster.exceptions
+
+import redgrease.client
+
+
+@redgrease.client.geared
+class RedisCluster(rediscluster.RedisCluster):
+    """RedisCluster client class, with support for gears features
+
+    Behaves exactly like the rediscluster.RedisCluster client, but is extended with
+    a 'gears' property fo executiong Gears commands.
+
+    Attributes:
+        gears (redgrease.client.Gears):
+            Gears command client.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Instantiate a redis cluster client, with gears features"""
+
+        super().__init__(*args, **kwargs)
+
+
+def RedisGears(*args, **kwargs):
+    try:
+        return RedisCluster(*args, **kwargs)
+    except rediscluster.exceptions.RedisClusterException:
+        return redgrease.client.Redis(*args, **kwargs)

--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -25,5 +25,6 @@ class RedisCluster(rediscluster.RedisCluster):
 def RedisGears(*args, **kwargs):
     try:
         return RedisCluster(*args, **kwargs)
-    except rediscluster.exceptions.RedisClusterException:
+
+    except (AttributeError, rediscluster.exceptions.RedisClusterException):
         return redgrease.client.Redis(*args, **kwargs)

--- a/src/redgrease/command.py
+++ b/src/redgrease/command.py
@@ -70,7 +70,7 @@ def get_runtime_client():
     # Swapping out the `execute_command` method for a replacement that uses the global
     # `execute` internally instead of the connection pool.
 
-    runtime_client = redgrease.client.RedisGears(connection_pool=...)
+    runtime_client = redgrease.client.Redis(connection_pool=...)
 
     runtime_client.execute_command = types.MethodType(
         _runtime_execute_command, runtime_client

--- a/src/redgrease/command.py
+++ b/src/redgrease/command.py
@@ -78,5 +78,7 @@ def get_runtime_client():
     return runtime_client
 
 
-redis = get_runtime_client()  # noqa: F811 - Used as exported var
+cmd = get_runtime_client()  # noqa: F811 - Used as exported var
 """ Runtime / serverside redis client with gears features"""
+
+__all__ = ["cmd"]

--- a/src/redgrease/loader.py
+++ b/src/redgrease/loader.py
@@ -40,7 +40,7 @@ from redis.exceptions import RedisError, ResponseError
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
-from redgrease import client, formatting, hysteresis, requirements
+from redgrease import RedisGears, formatting, hysteresis, requirements
 
 log = logging.getLogger(__name__)
 
@@ -174,7 +174,7 @@ class GearsLoader:
 
         self.index_prefix = index_prefix if index_prefix else default_index_prefix
 
-        self.redis = client.RedisGears(host=server, port=port, **redis_kwargs)
+        self.redis = RedisGears(host=server, port=port, **redis_kwargs)
 
         self.observer = Observer() if observe else None
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,6 +4,7 @@ ConfigArgParse
 packaging
 pyyaml
 redis
+redis-py-cluster
 typing-extensions # for python 3.6, 3.7 compatibility only
 watchdog
 wrapt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ from docker import DockerClient
 from docker.errors import APIError as DockerError
 
 import redgrease
-import redgrease.client
 
 redgrease_version = os.getenv(
     "REDGREASE_VERSION", importlib_metadata.version("redgrease")
@@ -121,13 +120,13 @@ def server_connection_params(redgrease_runtime_container):
 
 @pytest.fixture()
 def clean_redisgears_instance(server_connection_params):
-    """redgrease.client.RedisGears client instance from the redgrease package,
+    """redgrease.RedisGears client instance from the redgrease package,
     connected to the test server.
 
     This client instance is the SOT for most of the tests.
     """
     return instantiate(
-        redgrease.client.RedisGears,
+        redgrease.RedisGears,
         **server_connection_params,
     )
 

--- a/tests/test_builtin_runtime_functions.py
+++ b/tests/test_builtin_runtime_functions.py
@@ -37,9 +37,8 @@ import importlib_metadata
 import pytest
 import redis.exceptions
 
-import redgrease.client
 import redgrease.data
-from redgrease.client import RedisGears
+from redgrease import RedisGears
 
 redgrease_version = importlib_metadata.version("redgrease")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,7 +35,6 @@ import pytest
 import redgrease
 import redgrease.client
 import redgrease.data
-from redgrease.client import RedisGears
 from redgrease.utils import safe_str, str_if_bytes
 
 # Other things to test:
@@ -44,7 +43,7 @@ from redgrease.utils import safe_str, str_if_bytes
 
 
 @pytest.mark.parametrize("package", ["numpy"])
-def test_pydumpreqs(rg: RedisGears, package):
+def test_pydumpreqs(rg: redgrease.RedisGears, package):
     orig_reqs = rg.gears.pydumpreqs()
     assert isinstance(orig_reqs, list)
 
@@ -79,7 +78,7 @@ def test_pydumpreqs(rg: RedisGears, package):
     ids=lambda x: f"{len(x)}arg",
 )
 @pytest.mark.parametrize("mode", ["blocking", "unblocking"])
-def test_trigger(rg: RedisGears, arg_list: List, mode: str):
+def test_trigger(rg: redgrease.RedisGears, arg_list: List, mode: str):
     triggger_name = "Bang"
     unblocking: bool = mode == "unblocking"
     fun_str = (
@@ -99,7 +98,7 @@ def test_trigger(rg: RedisGears, arg_list: List, mode: str):
 
 
 @pytest.mark.parametrize("mode", ["blocking", "unblocking"])
-def test_dumpregistrations(rg: RedisGears, mode: str):
+def test_dumpregistrations(rg: redgrease.RedisGears, mode: str):
     triggger_name = "Bang"
     unblocking: bool = mode == "unblocking"
     fun_str = (
@@ -165,7 +164,7 @@ def test_dumpregistrations(rg: RedisGears, mode: str):
     assert reg2.RegistrationData.numSuccess == reg.RegistrationData.numSuccess + 1
 
 
-def test_unregister(rg: RedisGears):
+def test_unregister(rg: redgrease.RedisGears):
     triggger_name = "Bang"
     fun_str = (
         """GB('CommandReader')"""
@@ -189,7 +188,7 @@ def test_unregister(rg: RedisGears):
 
 
 @pytest.mark.parametrize("fun_str", ["GB().run()"])
-def test_getexecution(rg: RedisGears, fun_str: str):
+def test_getexecution(rg: redgrease.RedisGears, fun_str: str):
     # TODO: Test cluster Mode more properly
 
     exec = rg.gears.pyexecute(fun_str, unblocking=True)
@@ -231,7 +230,7 @@ def test_getexecution(rg: RedisGears, fun_str: str):
         assert isinstance(exe_step.arg, str)
 
 
-def test_getresults(rg: RedisGears):
+def test_getresults(rg: redgrease.RedisGears):
     rg.set("AKEY", 42)
     rg.set("ANOTHERKEY", 1)
 
@@ -254,26 +253,26 @@ def test_getresults(rg: RedisGears):
 
 
 @pytest.mark.xfail(reason="Testcase not implemented")
-def test_getresultsblocking(rg: RedisGears):
+def test_getresultsblocking(rg: redgrease.RedisGears):
     assert False
 
 
 @pytest.mark.xfail(reason="Testcase not implemented")
-def test_dumpexecutions(rg: RedisGears):
+def test_dumpexecutions(rg: redgrease.RedisGears):
     assert False
 
 
 @pytest.mark.xfail(reason="Testcase not implemented")
-def test_dropexecution(rg: RedisGears):
+def test_dropexecution(rg: redgrease.RedisGears):
     assert False
 
 
 @pytest.mark.xfail(reason="Testcase not implemented")
-def test_abortexecution(rg: RedisGears):
+def test_abortexecution(rg: redgrease.RedisGears):
     assert False
 
 
-def test_pystats(rg: RedisGears):
+def test_pystats(rg: redgrease.RedisGears):
     stats = rg.gears.pystats()
     assert stats
     assert isinstance(stats, redgrease.data.PyStats)
@@ -293,7 +292,7 @@ def test_pystats(rg: RedisGears):
 
 # TODO: Actually test on a cluster setup
 @pytest.mark.parametrize("cluster_mode", [False])
-def test_infocluster(rg: RedisGears, cluster_mode):
+def test_infocluster(rg: redgrease.RedisGears, cluster_mode):
     info = rg.gears.infocluster()
     # Non-c
     if not cluster_mode:
@@ -304,7 +303,7 @@ def test_infocluster(rg: RedisGears, cluster_mode):
 
 
 # TODO: Actually test on a cluster setup
-def test_refreshcluster(rg: RedisGears):
+def test_refreshcluster(rg: redgrease.RedisGears):
     # Pretty pointless test, but anyway
     # TODO: Somehow validate that it is run... Unsure of how though
     # TODO: See issue #11

--- a/tests/test_gears_config.py
+++ b/tests/test_gears_config.py
@@ -30,7 +30,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 import pytest
 import redis.exceptions
 
-from redgrease.client import RedisGears
+from redgrease import RedisGears
 
 
 @pytest.mark.parametrize("case", ["", "upper", "lower"])

--- a/tests/test_prog_gears.py
+++ b/tests/test_prog_gears.py
@@ -31,8 +31,7 @@ import sys
 import pytest
 import redis.exceptions
 
-from redgrease import GearsBuilder, execute, hashtag
-from redgrease.client import RedisGears
+from redgrease import GearsBuilder, execute, hashtag, RedisGears
 
 counter = 0
 

--- a/tests/test_prog_gears.py
+++ b/tests/test_prog_gears.py
@@ -31,7 +31,7 @@ import sys
 import pytest
 import redis.exceptions
 
-from redgrease import GearsBuilder, execute, hashtag, RedisGears
+from redgrease import GearsBuilder, RedisGears, execute, hashtag
 
 counter = 0
 

--- a/tests/test_runtime_redis_api.py
+++ b/tests/test_runtime_redis_api.py
@@ -31,7 +31,8 @@ from pathlib import Path
 
 import pytest
 
-from redgrease.client import RedisGears, safe_str
+from redgrease import RedisGears
+from redgrease.utils import safe_str
 
 scripts_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gear_scripts")
 


### PR DESCRIPTION
# Pull Request Overview:
Client support for cluster

# Main Changes:
- Added RedisCluster to redgrease.client
- Added `geared` decorator to redgrease.client
- `RedisGears` now tries to instantiate as `RedisCluster`, and falls back on `Redis` if it fails.

# Additional Info
- Lost typing and stuff for the clients.. must fix!


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
