### PR TITLE
Fixed erroneous run, register defaults (convertToStr, collect)

### DIFF
--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -1365,8 +1365,8 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
     def run(
         self,
         arg: str = None,  # TODO: This can also be a Python generator
-        convertToStr: bool = False,
-        collect: bool = False,
+        convertToStr: bool = True,
+        collect: bool = True,
         # Helpers, all must be None
         # Other Redgrease args
         requirements: Iterable[str] = None,
@@ -1434,8 +1434,8 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
     def register(  # noqa: C901
         self,
         prefix: str = "*",
-        convertToStr: bool = False,
-        collect: bool = False,
+        convertToStr: bool = True,
+        collect: bool = True,
         # Helpers, all must be None
         mode: str = None,
         onRegistered: "optype.Callback" = None,

--- a/tests/test_gearfunction_gearsbuilder.py
+++ b/tests/test_gearfunction_gearsbuilder.py
@@ -277,7 +277,9 @@ def test_hashtag(rg: RedisGears):
     raises=redis.exceptions.ResponseError,
 )
 def test_register(rg: RedisGears):
-    gear_fun = GearsBuilder("CommandReader").register(trigger="test")
+    gear_fun = GearsBuilder("CommandReader").register(
+        trigger="test", convertToStr=False
+    )
     res = rg.gears.pyexecute(gear_fun)
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")

--- a/tests/test_gearsfunction_readers.py
+++ b/tests/test_gearsfunction_readers.py
@@ -102,7 +102,7 @@ def test_shardsidreader(rg: RedisGears):
     raises=redis.exceptions.ResponseError,
 )
 def test_command_reader(rg: RedisGears):
-    gear_fun = CommandReader().register(trigger="test")
+    gear_fun = CommandReader().register(trigger="test", convertToStr=False)
     res = rg.gears.pyexecute(gear_fun)
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")


### PR DESCRIPTION
# Pull Request Overview:
- fixed issue #65 

# Main Changes:
- changed the defaults of `convertToStr` and `collect` argument  to `True`  for `PartialGearFunction.run` and `PartialGearFunction.register` methods, to behave correctly as the native "string" Gear function counterparts.
- Updated the CommandReader tests to override `convertToStr` to False

# Additional Info
None


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
