### PR TITLE
fixed cluster commands

### DIFF
--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -255,7 +255,7 @@ class Gears:
 
         Returns:
             redgredase.data.ClusterInfo:
-                Cluster information or None if not ion cluster mode.
+                Cluster information or None if not in cluster mode.
         """
         return self.redis.execute_command("RG.INFOCLUSTER")
 

--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -2,6 +2,12 @@ import rediscluster
 import rediscluster.exceptions
 
 import redgrease.client
+import redgrease.data
+import redgrease.utils
+
+
+def nop(*args):
+    return args
 
 
 @redgrease.client.geared
@@ -15,6 +21,37 @@ class RedisCluster(rediscluster.RedisCluster):
         gears (redgrease.client.Gears):
             Gears command client.
     """
+
+    # States how target node is selected for cluster commands:
+    # - blocked : command is not allowed - Raises a RedisClusterException
+    # - random : excuted on one randomly selected node
+    # - all-masters : executed on all master node
+    # - all-nodes : executed on all nodes
+    # - slot-id : executed on the node defined by the second argument
+    NODES_FLAGS = {
+        **rediscluster.RedisCluster.NODES_FLAGS,
+        **{
+            "RG.INFOCLUSTER": "random",
+            "RG.PYSTATS": "all-nodes",
+            "RG.PYDUMPREQS": "random",
+            "RG.REFRESHCLUSTER": "all-nodes",
+        },
+    }
+
+    # Not to be confused with redis.Redis.RESPONSE_CALLBACKS
+    # RESULT_CALLBACKS is special to rediscluster.RedisCluster.
+    # It decides how results of commands defined in `NODES_FLAGS` are aggregated into
+    # a final response, **after** redis.Redis.RESPONSE_CALLBACKS as been applied to
+    # each response individually.
+    RESULT_CALLBACKS = {
+        **rediscluster.RedisCluster.RESULT_CALLBACKS,
+        **{
+            "RG.INFOCLUSTER": lambda _, res: next(iter(res.values())),
+            "RG.PYSTATS": lambda _, res: res,
+            "RG.PYDUMPREQS": lambda _, res: next(iter(res.values())),
+            "RG.REFRESHCLUSTER": lambda _, res: all(res.values()),
+        },
+    }
 
     def __init__(self, *args, **kwargs):
         """Instantiate a redis cluster client, with gears features"""

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -526,6 +526,9 @@ class ShardInfo(RedisObject):
     maxHslot: int
     """Highest hash slot served by the shard."""
 
+    pendingMessages: int
+    """Number of pending messages"""
+
 
 @attr.s(auto_attribs=True, frozen=True)
 class ClusterInfo(RedisObject):
@@ -537,8 +540,10 @@ class ClusterInfo(RedisObject):
     my_id: str
     """The identifier of the shard the client is connected to."""
 
+    my_run_id: str
+
     shards: List[ShardInfo] = attr.ib(
-        converter=list_parser(ShardInfo.from_redis)  # type: ignore #7912
+        converter=list_parser(ShardInfo.from_redis)  # type: ignore e#7912
     )
     """List of the all the shards in the cluster."""
 
@@ -559,7 +564,8 @@ class ClusterInfo(RedisObject):
 
         cluster_info = ClusterInfo(
             my_id=safe_str(res[1]),
-            shards=res[2],
+            my_run_id=safe_str(res[3]),
+            shards=res[4],
         )
 
         return cluster_info

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -543,7 +543,7 @@ class ClusterInfo(RedisObject):
     my_run_id: str
 
     shards: List[ShardInfo] = attr.ib(
-        converter=list_parser(ShardInfo.from_redis)  # type: ignore e#7912
+        converter=list_parser(ShardInfo.from_redis)  # type: ignore
     )
     """List of the all the shards in the cluster."""
 


### PR DESCRIPTION
# Pull Request Overview:
- Fix for issue #60 and #11 

# Main Changes:
- fixed parsing issue with `RG.INFOCLUSTER` as the results have undocumented fields (`MyRunId` and shard->`pendingMessages`)
- In cluster mode,  `RG.INFOCLUSTER` is executed against a random node.
- In cluster mode, `RG.PYSTATS` is executed against all nodes.
- In cluster mode, `RG.PYDUMPREQS` is executed against a random node.
- In cluster mode, `RG.REFRESHCLUSTER` is executed against all nodes (issued #11)

# Additional Info
- None

# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    MORE TESTS ARE NEEDED!!!
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
