### PR TITLE
Generalized client constructor

### DIFF
--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -69,9 +69,9 @@ __all__ = [
 
 try:
     # This will fail if redis package is not installed
-    from .client import Gears, Redis, geared
+    from .client import Gears, Redis
 
-    __all__ += ["Gears", "Redis", "geared"]
+    __all__ += ["Gears", "Redis"]
 
     try:
         # This will fail if redis-py-cluster package is not installed

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -458,36 +458,6 @@ class Gears:
         return self.redis.execute_command("RG.UNREGISTER", id)
 
 
-def geared(cls):
-    class GearsClient(cls):
-
-        RESPONSE_CALLBACKS = {
-            **redis.Redis.RESPONSE_CALLBACKS,
-            **Gears.RESPONSE_CALLBACKS,
-        }
-
-        def __init__(self, *args, **kwargs):
-            self._gears = None
-            self.connection = None
-            super().__init__(*args, **kwargs)
-
-        @property
-        def gears(self) -> Gears:
-            """Gears client, exposing gears commands
-
-            Returns:
-                Gears:
-                    Gears client
-            """
-            if not self._gears:
-                self._gears = Gears(self)
-
-            return self._gears
-
-    return GearsClient
-
-
-@geared
 class Redis(redis.Redis):
     """Redis client class, with support for gears features.
 
@@ -499,6 +469,25 @@ class Redis(redis.Redis):
             Gears command client.
     """
 
+    RESPONSE_CALLBACKS = {
+        **redis.Redis.RESPONSE_CALLBACKS,
+        **Gears.RESPONSE_CALLBACKS,
+    }
+
     def __init__(self, *args, **kwargs):
         """Instantiate a redis client, with gears features"""
+        self._gears = None
         super().__init__(*args, **kwargs)
+
+    @property
+    def gears(self) -> Gears:
+        """Gears client, exposing gears commands
+
+        Returns:
+            Gears:
+                Gears client
+        """
+        if not self._gears:
+            self._gears = Gears(self)
+
+        return self._gears

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -468,6 +468,7 @@ def geared(cls):
 
         def __init__(self, *args, **kwargs):
             self._gears = None
+            self.connection = None
             super().__init__(*args, **kwargs)
 
         @property

--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -6,11 +6,6 @@ import redgrease.data
 import redgrease.utils
 
 
-def nop(*args):
-    return args
-
-
-@redgrease.client.geared
 class RedisCluster(rediscluster.RedisCluster):
     """RedisCluster client class, with support for gears features
 
@@ -53,10 +48,29 @@ class RedisCluster(rediscluster.RedisCluster):
         },
     }
 
+    RESPONSE_CALLBACKS = {
+        **rediscluster.RedisCluster.RESPONSE_CALLBACKS,
+        **redgrease.client.Gears.RESPONSE_CALLBACKS,
+    }
+
     def __init__(self, *args, **kwargs):
         """Instantiate a redis cluster client, with gears features"""
-
+        self._gears = None
+        self.connection = None
         super().__init__(*args, **kwargs)
+
+    @property
+    def gears(self) -> redgrease.client.Gears:
+        """Gears client, exposing gears commands
+
+        Returns:
+            Gears:
+                Gears client
+        """
+        if not self._gears:
+            self._gears = redgrease.client.Gears(self)
+
+        return self._gears
 
 
 def RedisGears(*args, **kwargs):


### PR DESCRIPTION
# Pull Request Overview:
- `redgrease.RedisGears` can now properly instantiate both RedisCluser and simple single node Redis instances.

# Main Changes:
- Got rid of `@geared` decorator
- added a dummy `connection` property to RedisCluster subclass so that it does not fail during baseclass destructor call.

# Additional Info
Nothing


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
