### PR TITLE
Added undocumented 'status' in RegistrationData

### DIFF
--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -409,6 +409,7 @@ class RegData(RedisObject):
         converter=optional(bool_ok),  # type: ignore #7912
         default=None,
     )
+    """Undocumented status field"""
 
 
 # @dataclass

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -45,6 +45,7 @@ from redgrease.utils import (
     REnum,
     bool_ok,
     list_parser,
+    optional,
     safe_bool,
     safe_str,
     str_if_bytes,
@@ -403,6 +404,11 @@ class RegData(RedisObject):
 
     args: Dict[str, Any] = attr.ib(converter=to_kwargs)
     """Reader-specific arguments"""
+
+    status: Optional[bool] = attr.ib(
+        converter=optional(bool_ok),  # type: ignore #7912
+        default=None,
+    )
 
 
 # @dataclass

--- a/src/redgrease/utils.py
+++ b/src/redgrease/utils.py
@@ -184,6 +184,13 @@ def bool_ok(value: Any) -> bool:
         return False
 
 
+def optional(constructor):
+    def parser(value: Any):
+        return None if value is None else constructor(value)
+
+    return parser
+
+
 def safe_bool(input: Any) -> bool:
     """Parse a bool, slightly more accepting
     allowing for literal "True"/"False", integer 0/1,

--- a/src/redgrease/utils.py
+++ b/src/redgrease/utils.py
@@ -184,8 +184,16 @@ def bool_ok(value: Any) -> bool:
         return False
 
 
-def optional(constructor):
-    def parser(value: Any):
+def optional(constructor: Constructor[T]) -> Constructor[Optional[T]]:
+    """Create parser that accepts `None` values, but otherwise behaves like the
+    provided parser.
+
+    Args:
+        constructor (Constructor[T]):
+            constructor to apply, unless the value is None.
+    """
+
+    def parser(value):
         return None if value is None else constructor(value)
 
     return parser


### PR DESCRIPTION
# Pull Request Overview:
- when calling `dumpregstrations` there are sometimes an undocumented field `status` under `RegistrationData`. When it appears it takes the value `Ok` so it is for now assumed to be boolean. The default is set to None, until it's clearer what it is used for.

# Main Changes:
- added a new util parser function `optional` that takes a parser as argument and returns a new parser that allows for `None` values, but otherwise behaves as the provided parser.
- Added an optional boolean `status` field to `RegData`

# Additional Info
None


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [x] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
