### PR TITLE
Docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ exclude_patterns: List[str] = []
 
 # -- Options for HTML output -------------------------------------------------
 
-pygments_style = "fruity"
+# pygments_style = "fruity"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -73,4 +73,5 @@ html_favicon = "../images/LyngonIcon_v3.ico"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 # custom.css is inside one of the html_static_path folders (e.g. _static)
-html_css_files = ["custom.css"]
+# html_css_files = ["custom.css"]
+html_css_files = []  # type: List[str]

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -98,7 +98,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
 
     Extended versions of the `redis <https://pypi.org/project/redis/>`_ and `redis-py_cluster <https://github.com/Grokzen/redis-py-cluster>`_ clients, but with additional pythonic functions, mapping closely (1-to-1) to the :ref:`Redis Gears command set <client_gears_commands>` (e.g. `RG.PYEXECUTE`, `RG.GETRESULT`, `RG.TRIGGER`, `RG.DUMPREGISTRATIONS` etc), outlined in the `official Gears documentation <https://oss.redislabs.com/redisgears/commands.html>`_.
 
-    .. code-block:: python3
+    .. code-block:: python
         :emphasize-lines: 6
 
         import redgrease
@@ -121,7 +121,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
     Allowing for **all** Redis (v.6) commands to be executed on serverside as if using a Redis 'client' class, instead of *manually* invoking the corresponding commmand string using ``execute()``. 
     It is basically the `redis <https://pypi.org/project/redis/>`_ client, but with ``execute_command()`` rewired to use the Gears-native ``execute()`` instead under the hood. 
 
-    .. code-block:: python3
+    .. code-block:: python
         :emphasize-lines: 8, 11, 13
 
         import redgrease
@@ -159,7 +159,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
 
     |br|
 
-    .. code-block:: python3
+    .. code-block:: python
 
         import redgrease
         from redgrease.utils import as_is

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -98,7 +98,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
 
     Extended versions of the `redis <https://pypi.org/project/redis/>`_ and `redis-py_cluster <https://github.com/Grokzen/redis-py-cluster>`_ clients, but with additional pythonic functions, mapping closely (1-to-1) to the :ref:`Redis Gears command set <client_gears_commands>` (e.g. `RG.PYEXECUTE`, `RG.GETRESULT`, `RG.TRIGGER`, `RG.DUMPREGISTRATIONS` etc), outlined in the `official Gears documentation <https://oss.redislabs.com/redisgears/commands.html>`_.
 
-    .. code-block:: python
+    .. code-block:: python3
         :emphasize-lines: 6
 
         import redgrease
@@ -121,7 +121,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
     Allowing for **all** Redis (v.6) commands to be executed on serverside as if using a Redis 'client' class, instead of *manually* invoking the corresponding commmand string using ``execute()``. 
     It is basically the `redis <https://pypi.org/project/redis/>`_ client, but with ``execute_command()`` rewired to use the Gears-native ``execute()`` instead under the hood. 
 
-    .. code-block:: python
+    .. code-block:: python3
         :emphasize-lines: 8, 11, 13
 
         import redgrease
@@ -159,7 +159,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
 
     |br|
 
-    .. code-block:: python
+    .. code-block:: python3
 
         import redgrease
         from redgrease.utils import as_is

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for building the Documentation
 readthedocs-sphinx-search==0.1.0
-sphinx==3.4.3
-sphinx-rtd-theme==0.1.5
+sphinx==3.5.3
+sphinx-rtd-theme==0.5.1
 Pygments==2.8.1

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -2,3 +2,4 @@
 readthedocs-sphinx-search==0.1.0
 sphinx==3.4.3
 sphinx-rtd-theme==0.1.5
+Pygments==2.8.1


### PR DESCRIPTION
# Pull Request Overview:
Updater RTD theme version from 0.1.5 (typo) to 0.5.1, fixing the code highlighting issue (and more) in the docs.

# Main Changes:
- updated RTD theme version
- spelling fixes
- some cleanup

# Additional Info
No


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
