### PR TITLE
Issue 81 gears builder

### DIFF
--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -57,6 +57,7 @@ import redgrease.data
 import redgrease.gears
 import redgrease.reader
 import redgrease.requirements
+import redgrease.runtime
 from redgrease.utils import (
     CaseInsensitiveDict,
     bool_ok,
@@ -261,7 +262,9 @@ class Gears:
 
     def pyexecute(
         self,
-        gear_function: Union[str, redgrease.gears.ClosedGearFunction] = "",
+        gear_function: Union[
+            str, redgrease.runtime.GearsBuilder, redgrease.gears.GearFunction
+        ] = "",
         unblocking=False,
         requirements: Optional[
             Iterable[Union[str, redgrease.requirements.Requirement]]
@@ -343,6 +346,9 @@ class Gears:
 
         requirements = set(requirements if requirements else [])
         result_function = None
+
+        if isinstance(gear_function, redgrease.runtime.GearsBuilder):
+            gear_function = gear_function._function
 
         if isinstance(gear_function, redgrease.gears.GearFunction):
             # If the input is a GearFunction, we get the requirements from it,

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -674,7 +674,7 @@ def deseralize_gear_function(
         raise
 
 
-def seralize_gear_function(gear_function: redgrease.gears.ClosedGearFunction) -> str:
+def seralize_gear_function(gear_function: redgrease.gears.GearFunction) -> str:
     """Serializes a GearFunction into a wrapper code-string that can be sent to the
     Gear server to execute.
 

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -1264,7 +1264,7 @@ class GearFunction(Generic[T]):
     def __init__(
         self,
         operation: Operation,
-        input_function: "PartialGearFunction",
+        input_function: "PartialGearFunction" = None,
         requirements: Optional[Iterable[str]] = None,
     ) -> None:
         """Instaniate a GearFunction
@@ -1285,12 +1285,11 @@ class GearFunction(Generic[T]):
         """
 
         self.operation = operation
-
+        self.input_function = input_function
         self.requirements = set(requirements if requirements else [])
 
-        if input_function is not self:
+        if input_function:
             self.requirements = self.requirements.union(input_function.requirements)
-            self.input_function = input_function
 
     @property
     def reader(self) -> Optional[str]:

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -1693,6 +1693,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Map operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Map(op=op, **kwargs),
@@ -1727,6 +1731,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a FlatMap operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             FlatMap(op=op, **kwargs),
@@ -1760,6 +1768,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a ForEach operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             ForEach(op=op, **kwargs),
@@ -1795,6 +1807,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a FIlter operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Filter(op=op, **kwargs),
@@ -1833,6 +1849,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with Accumulate operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Accumulate(op=op, **kwargs),
@@ -1877,6 +1897,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a LocalGroupBy operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             LocalGroupBy(extractor=extractor, reducer=reducer, **kwargs),
@@ -1911,6 +1935,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Limit operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Limit(length=length, start=start, **kwargs),
@@ -1927,6 +1955,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Collect operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Collect(**kwargs),
@@ -1964,6 +1996,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Repartition operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Repartition(extractor=extractor, **kwargs),
@@ -2017,6 +2053,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Aggregate operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Aggregate(zero=zero, seqOp=seqOp, combOp=combOp, **kwargs),
@@ -2077,6 +2117,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a AggregateBy operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             AggregateBy(
@@ -2121,6 +2165,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a GroupBy operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             GroupBy(extractor=extractor, reducer=reducer, **kwargs),
@@ -2163,6 +2211,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a BatchGroupBy operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             BatchGroupBy(extractor=extractor, reducer=reducer, **kwargs),
@@ -2195,6 +2247,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Sort operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Sort(reverse=reverse, **kwargs),
@@ -2212,6 +2268,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Distinct operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Distinct(**kwargs),
@@ -2228,6 +2288,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a Count operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Count(**kwargs),
@@ -2262,6 +2326,10 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with a CountBy operation as last step.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             CountBy(extractor=extractor, **kwargs),
@@ -2297,6 +2365,11 @@ class PartialGearFunction(GearFunction["optype.InputRecord"]):
         Returns:
             PartialGearFunction:
                 A new partial gear function with an avg operation as last step.
+                GearsBuilder - The same GearBuilder, but with updated function.
+
+                Note that for GearBuilder this method does **not** return a new
+                GearFunction, but instead returns the same GearBuilder, but with its
+                internal function updaded.
         """
         return PartialGearFunction(
             Avg(extractor=extractor, **kwargs),

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -77,9 +77,7 @@ class GearReader(redgrease.gears.PartialGearFunction):
                 Defaults to None.
         """
         reader_op = redgrease.gears.Reader(reader, defaultArg, desc)
-        super().__init__(
-            operation=reader_op, input_function=self, requirements=requirements
-        )
+        super().__init__(operation=reader_op, requirements=requirements)
 
 
 class KeysReader(GearReader):

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -29,11 +29,11 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 from typing import Iterable, Optional
 
-import redgrease.runtime
+import redgrease.gears
 import redgrease.sugar
 
 
-class GearReader(redgrease.runtime.GearsBuilder):
+class GearReader(redgrease.gears.PartialGearFunction):
     """Base class for the Reader sugar classes.
 
     Extends `redgrease.runtime.GearsBuilder' with arguments for collecting
@@ -76,11 +76,9 @@ class GearReader(redgrease.runtime.GearsBuilder):
                 Package lependencies for the gear train.
                 Defaults to None.
         """
+        reader_op = redgrease.gears.Reader(reader, defaultArg, desc)
         super().__init__(
-            reader=reader,
-            defaultArg=defaultArg,
-            desc=desc,
-            requirements=requirements,
+            operation=reader_op, input_function=self, requirements=requirements
         )
 
 

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -37,10 +37,14 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class GearsBuilder:
+class GearsBuilder(redgrease.gears.PartialGearFunction):
     """The GearsBuilder class is imported to the runtime's environment by default.
 
     It exposes the functionality of the function's context builder.
+
+    Unlike Readers, the GearsBuilder mutates its function instead of creating a new one
+    for each operation. This behaviour is deliberate, in order to be consistent with
+    the "raw" string Gear functions.
     """
 
     def __init__(
@@ -99,49 +103,6 @@ class GearsBuilder:
         **kwargs,
         # TODO: Add all the Reader specific args here
     ) -> redgrease.gears.ClosedGearFunction:
-        """Create a closed batch function..
-
-        Batch functions are executed once and exits once the data is
-        exhausted by its reader.
-        Args:
-            arg (str, optional):
-                An optional argument that's passed to the reader as its defaultArg.
-                It means the following::
-                    - A glob-like pattern for the KeysReader and KeysOnlyReader readers.
-                    - A key name for the StreamReader reader.
-                    - A Python generator for the PythonReader reader.
-
-                Defaults to None.
-
-            convertToStr (bool, optional):
-                When `True` adds a map operation to the flow's end that stringifies
-                records.
-                Defaults to False.
-
-            collect (bool, optional):
-                When `True` adds a collect operation to flow's end.
-                Defaults to False.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            on (redis.Redis):
-                Immedeately execute the function on this Redis Gear server / cluster.
-
-            **kwargs:
-                Additional parameters to the run operation.
-
-        Returns:
-            Union[ClosedGearFunction, redgrease.data.ExecutionResult]:
-                A new closed batch function, if `on` is **not** specified.
-                An execution result, if `on` **is** specified.
-
-        Raises:
-            TypeError:
-                If the function does not support batch mode.
-        """
-
         return self._function.run(
             arg=arg,
             convertToStr=convertToStr,
@@ -175,130 +136,6 @@ class GearsBuilder:
         **kwargs,
         # TODO: Add all the Reader specific args here
     ) -> redgrease.gears.ClosedGearFunction:
-        """Create a closed event function.
-
-        Event functions are executed each time an event arrives.
-        Each time it is executed, the function operates on the event's
-        data and once done is suspended until its future invocations by
-        new events.
-        Args:
-            prefix (str, optional):
-                Key prefix pattern to match on.
-                Not relevant for 'CommandReader' readers (see 'trigger').
-                Defaults to '*'.
-
-            convertToStr (bool, optional):
-                When `True` adds a map  operation to the flow's end that stringifies
-                records.
-                Defaults to True.
-
-            collect (bool, optional):
-                When True adds a collect operation to flow's end.
-                Defaults to False.
-
-            mode (str, optional):
-                The execution mode of the function.
-                Can be one of::
-
-                    - 'async': Execution will be asynchronous across the entire
-                        cluster.
-                    - 'async_local': Execution will be asynchronous and restricted
-                        to the handling shard.
-                    - 'sync': Execution will be synchronous and local.
-                Defaults to 'async'.
-
-            onRegistered (Callback, optional):
-                A function that's called on each shard upon function registration.
-                It is a good place to initialize non-serializable objects such as
-                network connections.
-                Defaults to None.
-
-            eventTypes (Iterable[str], optional):
-                For KeysReader only.
-                A whitelist of event types that trigger execution when the KeysReader
-                are used. The list may contain one or more::
-
-                    - Any Redis or module command
-                    - Any Redis event
-
-                Defaults to None.
-
-            keyTypes (Iterable[str], optional):
-                For KeysReader and KeysOnlyReader only.
-                A whitelist of key types that trigger execution when using the
-                KeysReader or KeysOnlyReader readers.
-                The list may contain one or more from the following::
-
-                    - Redis core types: 'string', 'hash', 'list', 'set', 'zset'
-                        or 'stream'
-                    - Redis module types: 'module'
-
-                Defaults to None.
-
-            readValue (bool, optional):
-                For KeysReader only.
-                When `False` the value will not be read, so the 'type' and 'value'
-                of the record will be set to None.
-                Defaults to True.
-
-            batch (int, optional):
-                For StreamReader only.
-                The number of new messages that trigger execution.
-                Defaults to 1.
-
-            duration  (int, optional):
-                For StreamReader only.
-                The time to wait before execution is triggered, regardless of the batch
-                size (0 for no duration).
-                Defaults to 0.
-
-            onFailedPolcy (str, optional):
-                For StreamReader only.
-                The policy for handling execution failures.
-                May be one of::
-
-                    - 'continue': Ignores a failure and continues to the next execution.
-                        This is the default policy.
-                    - 'abort': Stops further executions.
-                    - 'retry': Retries the execution after an interval specified with
-                        onFailedRetryInterval (default is one second).
-
-                Defaults to 'continue'.
-
-            onFailedRetryInterval (int, optional):
-                For StreamReader only.
-                The interval (in milliseconds) in which to retry in case onFailedPolicy
-                is 'retry'.
-                Defaults to 1.
-
-            trimStream (bool, optional):
-                For StreamReader only.
-                When True the stream will be trimmed after execution
-                Defaults to True.
-
-            trigger (str):
-                For 'CommandReader' only, and mandatory.
-                The trigger string that will trigger the function.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            on (redis.Redis):
-                Immedeately execute the function on this Redis Gear server / cluster.
-
-            **kwargs:
-                Additional parameters to the register operation.
-
-        Returns:
-            Union[ClosedGearFunction, redgrease.data.ExecutionResult]:
-                A new closed event function, if `on` is **not** specified.
-                An execution result, if `on` **is** specified.
-
-        Raises:
-            TypeError:
-                If the function does not support event mode.
-        """
         return self._function.register(
             prefix=prefix,
             convertToStr=convertToStr,
@@ -330,26 +167,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local Map operation that performs a one-to-one (1:1) mapping of
-        records.
-
-        Args:
-            op (redgrease.typing.Mapper):
-                Function to map on the input records.
-                The function must take one argument as input (input record) and
-                return something as an output (output record).
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Map operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Map operation as last step.
-        """
         self._function = self._function.map(op=op, requirements=requirements, **kwargs)
 
         return self
@@ -362,26 +179,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local FlatMap operation that performs one-to-many (1:N) mapping
-        of records.
-
-        Args:
-            op (redgrease.typing.Expander):
-                Function to map on the input records.
-                The function must take one argument as input (input record) and
-                return an iterable as an output (output records).
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the FlatMap operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a FlatMap operation as last step.
-        """
         self._function = self._function.flatmap(
             op=op, requirements=requirements, **kwargs
         )
@@ -396,25 +193,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local ForEach operation performs one-to-the-same (1=1) mapping.
-
-        Args:
-            op (redgrease.typing.Processor):
-                Function to run on each of the input records.
-                The function must take one argument as input (input record) and
-                should not return anything.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the ForEach operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a ForEach operation as last step.
-        """
         self._function = self._function.foreach(
             op=op, requirements=requirements, **kwargs
         )
@@ -429,27 +207,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local Filter operation performs one-to-zero-or-one (1:bool)
-        filtering of records.
-
-        Args:
-            op (redgrease.typing.Filterer):
-                Function to apply on the input records, to decide which ones to keep.
-                The function must take one argument as input (input record) and
-                return a bool. The input records evaluated to `True` will be kept as
-                output records.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Filter operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a FIlter operation as last step.
-        """
         self._function = self._function.filter(
             op=op, requirements=requirements, **kwargs
         )
@@ -464,30 +221,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local Accumulate operation performs many-to-one mapping (N:1) of
-        records.
-
-        Args:
-            op (redgrease.typing.Accumulator):
-                Function to to apply on the input records.
-                The function must take two arguments as input:
-                    - the input record, and
-                    - An accumulator value.
-                It should aggregate the input record into the accumulator variable,
-                which stores the state between the function's invocations.
-                The function must return the accumulator's updated value.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Accumulate operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with Accumulate operation as last step.
-        """
         self._function = self._function.accumulate(
             op=op, requirements=requirements, **kwargs
         )
@@ -503,35 +236,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local LocalGroupBy operation performs many-to-less mapping (N:M)
-        of records.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-
-            reducer (redgrease.typing.Reducer):
-                Function to apply on the records of each group, to reduce to a single
-                value (per group).
-                The function must take (a) a key, (b) an input record and (c) a
-                variable that's called an accumulator.
-                It performs similarly to the accumulator callback, with the difference
-                being that it maintains an accumulator per reduced key / group.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the LocalGroupBy operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a LocalGroupBy operation as last step.
-        """
         if self._function:
             self._function = self._function.localgroupby(
                 extractor=extractor,
@@ -549,43 +253,11 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Instance-local Limit operation limits the number of records.
-
-        Args:
-            length (int):
-                The maximum number of records.
-
-            start (int, optional):
-                The index of the first input record.
-                Defaults to 0.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Limit operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Limit operation as last step.
-        """
-        if self._function:
-            self._function = self._function.limit(length=length, start=start, **kwargs)
+        self._function = self._function.limit(length=length, start=start, **kwargs)
 
         return self
 
     def collect(self, **kwargs) -> "GearsBuilder":
-        """Cluster-global Collect operation collects the result records.
-
-        Args:
-            **kwargs:
-                Additional parameters to the Collect operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Collect operation as last step.
-        """
         if self._function:
             self._function = self._function.collect(**kwargs)
 
@@ -599,34 +271,9 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Cluster-global Repartition operation repartitions the records by shuffling
-        them between shards.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function that takes a record and calculates a key that is used to
-                determine the hash slot, and consequently the shard, that the record
-                should migrate to to.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The hash slot, and consequently the destination shard, is determined by
-                hthe value of the key.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Repartition operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Repartition operation as last step.
-        """
-        if self._function:
-            self._function = self._function.repartition(
-                extractor=extractor, requirements=requirements, **kwargs
-            )
+        self._function = self._function.repartition(
+            extractor=extractor, requirements=requirements, **kwargs
+        )
 
         return self
 
@@ -640,51 +287,13 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Perform aggregation on all the execution data.
-
-        Args:
-            zero (Any):
-                The initial / zero value of the accumulator variable.
-
-            seqOp (redgrease.typing.Accumulator):
-                A function to be applied on each of the input records, locally per
-                shard.
-                It must take two parameters:
-                - an accumulator value, from previous calls
-                - an input record
-                The functoin aggregates the input into the accumulator variable,
-                which stores the state between the function's invocations.
-                The function must return the accumulator's updated value.
-
-            combOp (redgrease.typing.Accumulator):
-                A function to be applied on each of the aggregated results of the local
-                aggregation (i.e. the output of `seqOp`).
-                It must take two parameters:
-                - an accumulator value, from previous calls
-                - an input record
-                The functoin aggregates the input into the accumulator variable,
-                which stores the state between the function's invocations.
-                The function must return the accumulator's updated value.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Aggregate operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Aggregate operation as last step.
-        """
-        if self._function:
-            self._function = self._function.aggregate(
-                zero=zero,
-                seqOp=seqOp,
-                combOp=combOp,
-                requirements=requirements,
-                **kwargs,
-            )
+        self._function = self._function.aggregate(
+            zero=zero,
+            seqOp=seqOp,
+            combOp=combOp,
+            requirements=requirements,
+            **kwargs,
+        )
 
         return self
 
@@ -699,58 +308,14 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Like aggregate, but on each key, the key is extracted using the extractor.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-
-            zero (Any):
-                The initial / zero value of the accumulator variable.
-
-            seqOp (redgrease.typing.Accumulator):
-                A function to be applied on each of the input records, locally per
-                shard and group.
-                It must take two parameters:
-                - an accumulator value, from previous calls
-                - an input record
-                The functoin aggregates the input into the accumulator variable,
-                which stores the state between the function's invocations.
-                The function must return the accumulator's updated value.
-
-            combOp (redgrease.typing.Accumulator):
-                A function to be applied on each of the aggregated results of the local
-                aggregation (i.e. the output of `seqOp`).
-                It must take two parameters:
-                - an accumulator value, from previous calls
-                - an input record
-                The functoin aggregates the input into the accumulator variable,
-                which stores the state between the function's invocations.
-                The function must return the accumulator's updated value.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the AggregateBy operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a AggregateBy operation as last step.
-        """
-        if self._function:
-            self._function = self._function.aggregateby(
-                extractor=extractor,
-                zero=zero,
-                seqOp=seqOp,
-                combOp=combOp,
-                requirements=requirements,
-                **kwargs,
-            )
+        self._function = self._function.aggregateby(
+            extractor=extractor,
+            zero=zero,
+            seqOp=seqOp,
+            combOp=combOp,
+            requirements=requirements,
+            **kwargs,
+        )
 
         return self
 
@@ -763,33 +328,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Perform a many-to-less (N:M) grouping of records.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-
-            reducer (redgrease.typing.Reducer):
-                Function to apply on the records of each group, to reduce to a single
-                value (per group).
-                The function must take (a) a key, (b) an input record and (c) a
-                variable that's called an accumulator.
-                It performs similarly to the accumulator callback, with the difference
-                being that it maintains an accumulator per reduced key / group.
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the GroupBy operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated withh a GroupBy operation as last step.
-        """
         self._function = self._function.groupby(
             extractor=extractor, reducer=reducer, requirements=requirements, **kwargs
         )
@@ -805,33 +343,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Many-to-less (N:M) grouping of records.
-
-            Note: Using this operation may cause a substantial increase in memory usage
-                during runtime. Consider using the GroupBy
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-
-            reducer (redgrease.typing.Reducer):
-                Function to apply on the records of each group, to reduce to a single
-                value (per group).
-                The function must take (a) a key, (b) an input record and (c) a
-                variable that's called an accumulator.
-                It performs similarly to the accumulator callback, with the difference
-                being that it maintains an accumulator per reduced key / group.
-
-            **kwargs:
-                Additional parameters to the BatchGroupBy operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a BatchGroupBy operation as last step.
-        """
         self._function = self._function.batchgroupby(
             extractor=extractor, reducer=reducer, requirements=requirements, **kwargs
         )
@@ -846,24 +357,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Sort the records
-
-        Args:
-            reverse (bool, optional):
-                Sort in descending order (higer to lower).
-                Defaults to True.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the Sort operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Sort operation as last step.
-        """
         self._function = self._function.sort(
             reverse=reverse, requirements=requirements, **kwargs
         )
@@ -871,31 +364,11 @@ class GearsBuilder:
         return self
 
     def distinct(self, **kwargs) -> "GearsBuilder":
-        """Keep only the distinct values in the data.
-
-        Args:
-            **kwargs:
-                Additional parameters to the Distinct operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a Distinct operation as last step.
-        """
         self._function = self._function.distinct(**kwargs)
 
         return self
 
     def count(self, **kwargs) -> "GearsBuilder":
-        """Count the number of records in the execution.
-
-        Args:
-            **kwargs:
-                Additional parameters to the Count operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated witha Count operation as last step.
-        """
         self._function = self._function.count(**kwargs)
 
         return self
@@ -908,27 +381,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Counts the records grouped by key.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-                Defaults to 'lambda x: str(x)'.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the CountBy operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated with a CountBy operation as last step.
-        """
         self._function = self._function.countby(
             extractor=extractor,
             # Other Redgrease args
@@ -947,27 +399,6 @@ class GearsBuilder:
         # Other Redis Gears args
         **kwargs,
     ) -> "GearsBuilder":
-        """Calculating arithmetic average of the records.
-
-        Args:
-            extractor (redgrease.typing.Extractor):
-                Function to apply on the input records, to extact the grouping key.
-                The function must take one argument as input (input record) and
-                return a string (key).
-                The groups are defined by the value of the key.
-                Defaults to 'lambda x: float(x)'.
-
-            requirements (Iterable[str], optional):
-                Additional requirements / dedpendency Python packages.
-                Defaults to None.
-
-            **kwargs:
-                Additional parameters to the map operation.
-
-        Returns:
-            redgrease.runtime.GearsBuilder:
-                The GearsBuilder, updated withh an avg operation as last step.
-        """
         self._function = self._function.avg(
             extractor=extractor,
             # Other Redgrease args

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class GearsBuilder:  # (redgrease.gears.PartialGearFunction):
+class GearsBuilder:
     """The GearsBuilder class is imported to the runtime's environment by default.
 
     It exposes the functionality of the function's context builder.

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class GearsBuilder(redgrease.gears.PartialGearFunction):
+class GearsBuilder:  # (redgrease.gears.PartialGearFunction):
     """The GearsBuilder class is imported to the runtime's environment by default.
 
     It exposes the functionality of the function's context builder.
@@ -79,12 +79,247 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
         """
         requirements = kwargs.pop("requirements", None)
         reader_op = redgrease.gears.Reader(reader, defaultArg, desc, *args, **kwargs)
+        self._function: redgrease.gears.PartialGearFunction = (
+            redgrease.gears.PartialGearFunction(
+                operation=reader_op,
+                requirements=requirements,
+            )
+        )
 
-        super().__init__(
-            operation=redgrease.gears.Nop(),
-            input_function=redgrease.gears.PartialGearFunction(
-                operation=reader_op, input_function=self, requirements=requirements
-            ),
+    def run(
+        self,
+        arg: str = None,  # TODO: This can also be a Python generator
+        convertToStr: bool = True,
+        collect: bool = True,
+        # Helpers, all must be None
+        # Other Redgrease args
+        requirements: Iterable[str] = None,
+        on=None,
+        # Other Redis Gears args
+        **kwargs,
+        # TODO: Add all the Reader specific args here
+    ) -> redgrease.gears.ClosedGearFunction:
+        """Create a closed batch function..
+
+        Batch functions are executed once and exits once the data is
+        exhausted by its reader.
+        Args:
+            arg (str, optional):
+                An optional argument that's passed to the reader as its defaultArg.
+                It means the following::
+                    - A glob-like pattern for the KeysReader and KeysOnlyReader readers.
+                    - A key name for the StreamReader reader.
+                    - A Python generator for the PythonReader reader.
+
+                Defaults to None.
+
+            convertToStr (bool, optional):
+                When `True` adds a map operation to the flow's end that stringifies
+                records.
+                Defaults to False.
+
+            collect (bool, optional):
+                When `True` adds a collect operation to flow's end.
+                Defaults to False.
+
+            requirements (Iterable[str], optional):
+                Additional requirements / dedpendency Python packages.
+                Defaults to None.
+
+            on (redis.Redis):
+                Immedeately execute the function on this Redis Gear server / cluster.
+
+            **kwargs:
+                Additional parameters to the run operation.
+
+        Returns:
+            Union[ClosedGearFunction, redgrease.data.ExecutionResult]:
+                A new closed batch function, if `on` is **not** specified.
+                An execution result, if `on` **is** specified.
+
+        Raises:
+            TypeError:
+                If the function does not support batch mode.
+        """
+
+        return self._function.run(
+            arg=arg,
+            convertToStr=convertToStr,
+            collect=collect,
+            requirements=requirements,
+            on=on,
+            **kwargs,
+        )
+
+    def register(  # noqa: C901
+        self,
+        prefix: str = "*",
+        convertToStr: bool = True,
+        collect: bool = True,
+        # Helpers, all must be None
+        mode: str = None,
+        onRegistered: "optype.Callback" = None,
+        eventTypes: Iterable[str] = None,
+        keyTypes: Iterable[str] = None,
+        readValue: bool = None,
+        batch: int = None,
+        duration: int = None,
+        onFailedPolcy: str = None,
+        onFailedRetryInterval: int = None,
+        trimStream: bool = None,
+        trigger: str = None,  # Reader Specific: CommandReader
+        # Other Redgrease args
+        requirements: Iterable[str] = None,
+        on=None,
+        # Other Redis Gears args
+        **kwargs,
+        # TODO: Add all the Reader specific args here
+    ) -> redgrease.gears.ClosedGearFunction:
+        """Create a closed event function.
+
+        Event functions are executed each time an event arrives.
+        Each time it is executed, the function operates on the event's
+        data and once done is suspended until its future invocations by
+        new events.
+        Args:
+            prefix (str, optional):
+                Key prefix pattern to match on.
+                Not relevant for 'CommandReader' readers (see 'trigger').
+                Defaults to '*'.
+
+            convertToStr (bool, optional):
+                When `True` adds a map  operation to the flow's end that stringifies
+                records.
+                Defaults to True.
+
+            collect (bool, optional):
+                When True adds a collect operation to flow's end.
+                Defaults to False.
+
+            mode (str, optional):
+                The execution mode of the function.
+                Can be one of::
+
+                    - 'async': Execution will be asynchronous across the entire
+                        cluster.
+                    - 'async_local': Execution will be asynchronous and restricted
+                        to the handling shard.
+                    - 'sync': Execution will be synchronous and local.
+                Defaults to 'async'.
+
+            onRegistered (Callback, optional):
+                A function that's called on each shard upon function registration.
+                It is a good place to initialize non-serializable objects such as
+                network connections.
+                Defaults to None.
+
+            eventTypes (Iterable[str], optional):
+                For KeysReader only.
+                A whitelist of event types that trigger execution when the KeysReader
+                are used. The list may contain one or more::
+
+                    - Any Redis or module command
+                    - Any Redis event
+
+                Defaults to None.
+
+            keyTypes (Iterable[str], optional):
+                For KeysReader and KeysOnlyReader only.
+                A whitelist of key types that trigger execution when using the
+                KeysReader or KeysOnlyReader readers.
+                The list may contain one or more from the following::
+
+                    - Redis core types: 'string', 'hash', 'list', 'set', 'zset'
+                        or 'stream'
+                    - Redis module types: 'module'
+
+                Defaults to None.
+
+            readValue (bool, optional):
+                For KeysReader only.
+                When `False` the value will not be read, so the 'type' and 'value'
+                of the record will be set to None.
+                Defaults to True.
+
+            batch (int, optional):
+                For StreamReader only.
+                The number of new messages that trigger execution.
+                Defaults to 1.
+
+            duration  (int, optional):
+                For StreamReader only.
+                The time to wait before execution is triggered, regardless of the batch
+                size (0 for no duration).
+                Defaults to 0.
+
+            onFailedPolcy (str, optional):
+                For StreamReader only.
+                The policy for handling execution failures.
+                May be one of::
+
+                    - 'continue': Ignores a failure and continues to the next execution.
+                        This is the default policy.
+                    - 'abort': Stops further executions.
+                    - 'retry': Retries the execution after an interval specified with
+                        onFailedRetryInterval (default is one second).
+
+                Defaults to 'continue'.
+
+            onFailedRetryInterval (int, optional):
+                For StreamReader only.
+                The interval (in milliseconds) in which to retry in case onFailedPolicy
+                is 'retry'.
+                Defaults to 1.
+
+            trimStream (bool, optional):
+                For StreamReader only.
+                When True the stream will be trimmed after execution
+                Defaults to True.
+
+            trigger (str):
+                For 'CommandReader' only, and mandatory.
+                The trigger string that will trigger the function.
+
+            requirements (Iterable[str], optional):
+                Additional requirements / dedpendency Python packages.
+                Defaults to None.
+
+            on (redis.Redis):
+                Immedeately execute the function on this Redis Gear server / cluster.
+
+            **kwargs:
+                Additional parameters to the register operation.
+
+        Returns:
+            Union[ClosedGearFunction, redgrease.data.ExecutionResult]:
+                A new closed event function, if `on` is **not** specified.
+                An execution result, if `on` **is** specified.
+
+        Raises:
+            TypeError:
+                If the function does not support event mode.
+        """
+        return self._function.register(
+            prefix=prefix,
+            convertToStr=convertToStr,
+            collect=collect,
+            # Helpers
+            mode=mode,
+            onRegistered=onRegistered,
+            eventTypes=eventTypes,
+            keyTypes=keyTypes,
+            readValue=readValue,
+            batch=batch,
+            duration=duration,
+            onFailedPolcy=onFailedPolcy,
+            onFailedRetryInterval=onFailedRetryInterval,
+            trimStream=trimStream,
+            trigger=trigger,  # CommandReader specific
+            # Other Redgrease args
+            requirements=requirements,
+            on=on,
+            # Other Redis Gears args
+            **kwargs,
         )
 
     def map(
@@ -115,9 +350,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Map operation as last step.
         """
-        self.input_function = self.input_function.map(
-            op=op, requirements=requirements, **kwargs
-        )
+        self._function = self._function.map(op=op, requirements=requirements, **kwargs)
 
         return self
 
@@ -149,7 +382,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a FlatMap operation as last step.
         """
-        self.input_function = self.input_function.flatmap(
+        self._function = self._function.flatmap(
             op=op, requirements=requirements, **kwargs
         )
 
@@ -182,7 +415,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a ForEach operation as last step.
         """
-        self.input_function = self.input_function.foreach(
+        self._function = self._function.foreach(
             op=op, requirements=requirements, **kwargs
         )
 
@@ -217,7 +450,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a FIlter operation as last step.
         """
-        self.input_function = self.input_function.filter(
+        self._function = self._function.filter(
             op=op, requirements=requirements, **kwargs
         )
 
@@ -255,7 +488,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with Accumulate operation as last step.
         """
-        self.input_function = self.input_function.accumulate(
+        self._function = self._function.accumulate(
             op=op, requirements=requirements, **kwargs
         )
 
@@ -299,8 +532,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a LocalGroupBy operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.localgroupby(
+        if self._function:
+            self._function = self._function.localgroupby(
                 extractor=extractor,
                 reducer=reducer,
                 requirements=requirements,
@@ -337,10 +570,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Limit operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.limit(
-                length=length, start=start, **kwargs
-            )
+        if self._function:
+            self._function = self._function.limit(length=length, start=start, **kwargs)
 
         return self
 
@@ -355,8 +586,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Collect operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.collect(**kwargs)
+        if self._function:
+            self._function = self._function.collect(**kwargs)
 
         return self
 
@@ -392,8 +623,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Repartition operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.repartition(
+        if self._function:
+            self._function = self._function.repartition(
                 extractor=extractor, requirements=requirements, **kwargs
             )
 
@@ -446,8 +677,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Aggregate operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.aggregate(
+        if self._function:
+            self._function = self._function.aggregate(
                 zero=zero,
                 seqOp=seqOp,
                 combOp=combOp,
@@ -511,8 +742,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a AggregateBy operation as last step.
         """
-        if self.input_function:
-            self.input_function = self.input_function.aggregateby(
+        if self._function:
+            self._function = self._function.aggregateby(
                 extractor=extractor,
                 zero=zero,
                 seqOp=seqOp,
@@ -559,7 +790,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated withh a GroupBy operation as last step.
         """
-        self.input_function = self.input_function.groupby(
+        self._function = self._function.groupby(
             extractor=extractor, reducer=reducer, requirements=requirements, **kwargs
         )
 
@@ -601,7 +832,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a BatchGroupBy operation as last step.
         """
-        self.input_function = self.input_function.batchgroupby(
+        self._function = self._function.batchgroupby(
             extractor=extractor, reducer=reducer, requirements=requirements, **kwargs
         )
 
@@ -633,7 +864,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Sort operation as last step.
         """
-        self.input_function = self.input_function.sort(
+        self._function = self._function.sort(
             reverse=reverse, requirements=requirements, **kwargs
         )
 
@@ -650,7 +881,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a Distinct operation as last step.
         """
-        self.input_function = self.input_function.distinct(**kwargs)
+        self._function = self._function.distinct(**kwargs)
 
         return self
 
@@ -665,7 +896,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated witha Count operation as last step.
         """
-        self.input_function = self.input_function.count(**kwargs)
+        self._function = self._function.count(**kwargs)
 
         return self
 
@@ -698,7 +929,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated with a CountBy operation as last step.
         """
-        self.input_function = self.input_function.countby(
+        self._function = self._function.countby(
             extractor=extractor,
             # Other Redgrease args
             requirements=requirements,
@@ -737,7 +968,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             redgrease.runtime.GearsBuilder:
                 The GearsBuilder, updated withh an avg operation as last step.
         """
-        self.input_function = self.input_function.avg(
+        self._function = self._function.avg(
             extractor=extractor,
             # Other Redgrease args
             requirements=requirements,


### PR DESCRIPTION
# Pull Request Overview:
`GearsBuilder` is now mutable, to conform with "vanilla" (string) functions, while `Reader`s remain pure (issue #81).

# Main Changes:
- `GearsBuilder`  maintains a mutable internal state (`_function`, the built function) that is updated by its own version of the Gear operations. These versions return the GearBuilder itself, instead of the new function.
- `pyexecute` accepts `GearsBuilders` as well.
- added one test for this: `test_gearfunction_gearsbuilder.test_mutable_builder`

# Additional Info
None


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [x] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
