### PR TITLE
Issue 48 pickled results

### DIFF
--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -403,7 +403,6 @@ class Gears:
             "RG.PYEXECUTE",
             function_string,
             *params,
-            # pickled=isinstance(gear_function, redgrease.gears.GearFunction),
         )
         if result_function and command_response:
             return redgrease.data.ExecutionResult(result_function)

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -403,7 +403,7 @@ class Gears:
             "RG.PYEXECUTE",
             function_string,
             *params,
-            pickled=isinstance(gear_function, redgrease.gears.GearFunction),
+            # pickled=isinstance(gear_function, redgrease.gears.GearFunction),
         )
         if result_function and command_response:
             return redgrease.data.ExecutionResult(result_function)

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -222,10 +222,6 @@ def parse_execute_response(response) -> ExecutionResult:
             (e.g. in the absence of a closing `run()` operation) or an excecution ID
             (e.g. for non-blocking executions).
 
-        pickled (bool, optional):
-            Indicates if the response is pickled and need to be unpickled.
-            Defaults to False.
-
     Returns:
         ExecutionResult[T]:
             A parsed execution response

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -208,7 +208,7 @@ class ExecutionResult(wrapt.ObjectProxy, Generic[T]):
         return self.value(*args, **kwds)
 
 
-def parse_execute_response(response, pickled=False) -> ExecutionResult:
+def parse_execute_response(response) -> ExecutionResult:
     """Parses raw responses from `pyexecute`, `getresults` and `getresultsblocking`
     into a `redgrease.data.ExecuteResponse` object.
 
@@ -244,8 +244,10 @@ def parse_execute_response(response, pickled=False) -> ExecutionResult:
 
         result, errors = response
         if isinstance(result, list):
-            if pickled:
+            try:
                 result = [cloudpickle.loads(value) for value in result]
+            except (TypeError, cloudpickle.pickle.UnpicklingError):
+                pass
             if len(result) == 1:
                 result = result[0]
         return ExecutionResult(result, errors=errors)

--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -255,7 +255,7 @@ def parse_execute_response(response) -> ExecutionResult:
         return ExecutionResult(response)
 
 
-def parse_trigger_response(response, pickled=False) -> ExecutionResult:
+def parse_trigger_response(response) -> ExecutionResult:
     """Parses raw responses from `trigger` into a `redgrease.data.ExecuteResponse`
     object.
 
@@ -273,8 +273,10 @@ def parse_trigger_response(response, pickled=False) -> ExecutionResult:
         ExecutionResult[T]:
             A parsed execution response
     """
-    if pickled:
+    try:
         response = [cloudpickle.loads(value) for value in response]
+    except (TypeError, cloudpickle.pickle.UnpicklingError):
+        pass
 
     if len(response) == 1:
         response = response[0]

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -248,13 +248,13 @@ class Run(Operation):
             ClosedGearFunction:
                 A closed Gear batch function that is ready to run on a Gears cluster.
         """
-        # import cloudpickle
+        import cloudpickle
 
-        # return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).run(
-        #     self.arg, False, self.collect, **self.kwargs
-        # )
+        return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).run(
+            self.arg, False, self.collect, **self.kwargs
+        )
 
-        return function.run(self.arg, self.convertToStr, self.collect, **self.kwargs)
+        # return function.run(self.arg, self.convertToStr, self.collect, **self.kwargs)
 
 
 class Register(Operation):
@@ -353,7 +353,9 @@ class Register(Operation):
                 A closed Gear event function that is ready to be regisetered on a
                 Gears cluster.
         """
-        return function.register(
+        import cloudpickle
+
+        return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).register(
             self.prefix,
             self.convertToStr,
             self.collect,

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -248,11 +248,13 @@ class Run(Operation):
             ClosedGearFunction:
                 A closed Gear batch function that is ready to run on a Gears cluster.
         """
-        import cloudpickle
+        # import cloudpickle
 
-        return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).run(
-            self.arg, False, self.collect, **self.kwargs
-        )
+        # return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).run(
+        #     self.arg, False, self.collect, **self.kwargs
+        # )
+
+        return function.run(self.arg, self.convertToStr, self.collect, **self.kwargs)
 
 
 class Register(Operation):

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -254,8 +254,6 @@ class Run(Operation):
             self.arg, False, self.collect, **self.kwargs
         )
 
-        # return function.run(self.arg, self.convertToStr, self.collect, **self.kwargs)
-
 
 class Register(Operation):
     """Register action
@@ -357,7 +355,7 @@ class Register(Operation):
 
         return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).register(
             self.prefix,
-            False,  # self.convertToStr,
+            False,
             self.collect,
             mode=self.mode,
             onRegistered=self.onRegistered,

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -357,7 +357,7 @@ class Register(Operation):
 
         return function.map(lambda x: cloudpickle.dumps(x, protocol=4)).register(
             self.prefix,
-            self.convertToStr,
+            False,  # self.convertToStr,
             self.collect,
             mode=self.mode,
             onRegistered=self.onRegistered,

--- a/tests/test_gearfunction_gearsbuilder.py
+++ b/tests/test_gearfunction_gearsbuilder.py
@@ -284,8 +284,7 @@ def test_register(rg: RedisGears):
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
-    # Todo: Is this the desired output?
-    assert res == [b"test", b"this", b"is", b"a", b"test"]
+    assert res == ["test", "this", "is", "a", "test"]
 
 
 @pytest.mark.xfail(

--- a/tests/test_gearsfunction_readers.py
+++ b/tests/test_gearsfunction_readers.py
@@ -171,8 +171,7 @@ def test_command_reader(rg: RedisGears):
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
-    # Todo: Is this the desired output? NO! Related to issue #48?
-    assert res == [b"test", b"this", b"is", b"a", b"test"]
+    assert res == ["test", "this", "is", "a", "test"]
 
 
 @pytest.mark.xfail(
@@ -187,8 +186,7 @@ def test_command_reader_args(rg: RedisGears):
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
-    # Todo: Is this the desired output? NO! Related to issue #48?
-    assert res == [b"this", b"is", b"a", b"test"]
+    assert res == ["this", "is", "a", "test"]
 
 
 @pytest.mark.xfail(
@@ -203,8 +201,7 @@ def test_command_reader_args_2(rg: RedisGears):
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
-    # Todo: Is this the desired output? NO! Related to issue #48?
-    assert res == [b"this", b"is"]
+    assert res == ["this", "is"]
 
 
 @pytest.mark.xfail(
@@ -224,7 +221,6 @@ def test_command_reader_apply(rg: RedisGears):
     assert res
     res = rg.gears.trigger("test", "this", "is", "a", "test")
     assert res
-    # Todo: Is this the desired output?
     assert res == 11
 
 


### PR DESCRIPTION
# Pull Request Overview:
Closing issue #48

# Main Changes:
- Always try to unpickle results from `ClosedGearFunction`s, and fallback to raw if it fails.
- (change 2)

# Additional Info
Currently `convertToStr` is just ignored for both `PartialGearFunction.run()` and `PartialGearFunction.register()`. 
It should ideally still be used in case the fallback kicks in, somehow.

See issue  #91


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [x] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
