### PR TITLE
fixed faulty examples

### DIFF
--- a/src/redgrease/data.py
+++ b/src/redgrease/data.py
@@ -569,7 +569,7 @@ class ClusterInfo(RedisObject):
                 A ClusterInfo object or None (if not in cluster mode).s
         """
 
-        if not res or res == b"no cluster mode":
+        if not res or safe_str(res) == "no cluster mode":
             return None
 
         cluster_info = ClusterInfo(

--- a/tests/gear_scripts/redislabs_mod_example_deletebykeyprefix.py
+++ b/tests/gear_scripts/redislabs_mod_example_deletebykeyprefix.py
@@ -1,4 +1,4 @@
 from redgrease import KeysReader, cmd
 
-delete_fun = KeysReader().keys().foreach(cmd.delete).count()
+delete_fun = KeysReader().keys().foreach(lambda k: cmd.delete(k)).count()
 delete_fun.run("delete_me:*")

--- a/tests/gear_scripts/redislabs_mod_example_distributedmontecarlotoestimatepi.py
+++ b/tests/gear_scripts/redislabs_mod_example_distributedmontecarlotoestimatepi.py
@@ -15,12 +15,11 @@ def throws():
     """ Calculates each shard's number of throws """
     global TOTAL_DARTS
     throws = TOTAL_DARTS
-    ci = cmd.gears.infocluster()
-    if type(ci) is not str:  # assume a cluster
-        n = len(ci[2])  # number of shards
-        me = ci[1]  # my shard's ID
-        ids = [x[1] for x in ci[2]].sort()  # shards' IDs list
-        i = ids.index(me)  # my index
+    cluster = cmd.gears.infocluster()
+    if cluster:  # assume a cluster
+        n = len(cluster.shards)  # number of shards
+        ids = sorted([shard.id for shard in cluster.shards])  # shards' IDs list
+        i = ids.index(cluster.my_id)  # my index
         throws = TOTAL_DARTS // n  # minimum throws per shard
         if i == 0 and TOTAL_DARTS % n > 0:  # first shard gets remainder
             throws += 1

--- a/tests/gear_scripts/redislabs_mod_example_wordcount.py
+++ b/tests/gear_scripts/redislabs_mod_example_wordcount.py
@@ -1,3 +1,3 @@
 from redgrease import KeysReader
 
-KeysReader().values().flatmap(str.split).countby().run()
+KeysReader().values().flatmap(lambda x: x.split()).countby().run()


### PR DESCRIPTION
# Pull Request Overview:
Corrected false assumption that method descriptors (like `str.split` and `redgrease.cmd.delete`) can be passed as callback functions to operators. 

# Main Changes:
- Replaced passing of method descriptors with explicit lambda functions in examples.
- Updated monte-carlo example to properly use `cmd.infocluster()`so it is much clearer. (... but still not working?)

# Additional Info
see issue #95 


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
