### PR TITLE
Issue 97 gearfun files

### DIFF
--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -32,6 +32,8 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 import sys
 
+from redgrease.data import T
+
 from .func import trigger
 from .gears import ClosedGearFunction, GearFunction, PartialGearFunction
 from .reader import (
@@ -128,6 +130,7 @@ except ModuleNotFoundError:
 # or not (e.g. dev or client)
 if "redisgears" in sys.modules:
     # Server Gears runtime environment
+    GEARS_RUNTIME = True
     # Import the default functions and classes
     # pyright: reportMissingImports=false
     from __main__ import GB as GB
@@ -138,8 +141,10 @@ if "redisgears" in sys.modules:
     from redisgears import executeCommand as execute
     from redisgears import getMyHashTag as hashtag
     from redisgears import log as log
+
 else:
     # Dev or Client environment
+    GEARS_RUNTIME = False
     # Import placeholder functions and
     from .runtime import (
         GB,
@@ -161,4 +166,5 @@ __all__ += [
     "gearsConfigGet",
     "hashtag",
     "log",
+    "GEARS_RUNTIME",
 ]

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -48,7 +48,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 import logging
 import os.path
-from typing import Any, Iterable, List, Mapping, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union
 
 import redis
 
@@ -88,7 +88,7 @@ class Gears:
             Redis Gears Configuration 'client'
     """
 
-    RESPONSE_CALLBACKS = {
+    RESPONSE_CALLBACKS: Dict[str, Callable] = {
         "RG.ABORTEXECUTION": bool_ok,
         "RG.CONFIGGET": dict_of(
             CaseInsensitiveDict(redgrease.config.Config.ValueTypes)

--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -1,3 +1,5 @@
+from typing import Callable, Dict
+
 import rediscluster
 import rediscluster.exceptions
 
@@ -48,7 +50,7 @@ class RedisCluster(rediscluster.RedisCluster):
         },
     }
 
-    RESPONSE_CALLBACKS = {
+    RESPONSE_CALLBACKS: Dict[str, Callable] = {
         **rediscluster.RedisCluster.RESPONSE_CALLBACKS,
         **redgrease.client.Gears.RESPONSE_CALLBACKS,
     }

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -26,8 +26,10 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
+
 from typing import Any, Dict, Generic, Hashable, Iterable, Optional, Type, TypeVar
 
+import redgrease
 import redgrease.sugar as sugar
 import redgrease.typing as optype
 
@@ -1450,6 +1452,9 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
             requirements=requirements,
         )
 
+        if redgrease.GEARS_RUNTIME:
+            return redgrease.runtime.run(gear_fun, redgrease.GearsBuilder)
+
         if on:
             return gear_fun.on(on)
 
@@ -1650,6 +1655,9 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
             input_function=self,
             requirements=requirements,
         )
+
+        if redgrease.GEARS_RUNTIME:
+            return redgrease.runtime.run(gear_fun, redgrease.GearsBuilder)
 
         if on:
             return gear_fun.on(on)

--- a/tests/test_example_scripts.py
+++ b/tests/test_example_scripts.py
@@ -29,13 +29,11 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 """
 import os
 import re
-import unittest.mock
 from pathlib import Path
 from typing import Dict
 
 import importlib_metadata
 import pytest
-import redis.exceptions
 
 from redgrease import RedisGears
 

--- a/tests/test_example_scripts.py
+++ b/tests/test_example_scripts.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Redgrease overloads of the vanilla runtime functions that are loaded per
+default at top level in ter Redis Gears Python runtime environment.
+Such as `GearsBuilder`, `execute`, `log`, `atomic` etc.
+"""
+__author__ = "Anders Åström"
+__contact__ = "anders@lyngon.com"
+__copyright__ = "2021, Lyngon Pte. Ltd."
+__licence__ = """The MIT License
+Copyright © 2021 Lyngon Pte. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the “Software”), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify,
+ merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to the following
+ conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+ or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import os
+import re
+import unittest.mock
+from pathlib import Path
+from typing import Dict
+
+import importlib_metadata
+import pytest
+import redis.exceptions
+
+from redgrease import RedisGears
+
+redgrease_version = importlib_metadata.version("redgrease")
+
+scripts_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gear_scripts")
+
+explicit_redgrease_import = re.compile(r"from redgrease[^\n]+")
+
+
+def gear_script(file):
+    return os.path.join(scripts_dir, file)
+
+
+def gear_scripts(file_pattern):
+    directory = Path(str(scripts_dir))
+    return directory.rglob(file_pattern)
+
+
+def read(file_pattern):
+    directory = Path(str(scripts_dir))
+    files_contents = []
+    for file_path in directory.rglob(file_pattern):
+        with open(file_path, "r") as file:
+            files_contents.append((file_path.name, file.read()))
+    return files_contents
+
+
+# ################################# #
+# Tests                             #
+# ################################# #
+@pytest.mark.parametrize("enforce_redgrease", [True])
+@pytest.mark.parametrize(
+    "script_file",
+    [
+        gear_script("redislabs_example_wordcount.py"),
+        gear_script("redislabs_mod_example_wordcount.py"),
+    ],
+)
+def test_example_wordcount(rg: RedisGears, script_file: str, enforce_redgrease):
+    lines = [
+        "this is the first sentence of a lot of nonsense",
+        "the lines don`t mean a thing at all",
+        "the phrases are just words to count",
+        "enough of this nonsense lines of words",
+    ]
+    reference_word_counts: Dict[str, int] = {}
+    for i, line in enumerate(lines):
+        rg.set(f"line:{i}", line)
+        for word in line.split():
+            reference_word_counts[word] = reference_word_counts.get(word, 0) + 1
+
+        res = rg.gears.pyexecute(script_file, enforce_redgrease=enforce_redgrease)
+
+        assert res
+        assert isinstance(res.value, list)
+        assert len(res.value) == len(reference_word_counts)


### PR DESCRIPTION
# Pull Request Overview:
Script files with RedGrease GearFunctions can now be executed by filename.

# Main Changes:
- `redgrease.GEARS_RUNTIME` exposed and evaluates to `True` if in server RedisGears runtime, false otherwise.
- calling `run` or `register` on `PartialFunction`s when in "Gears runtime" (i.e. `redgrease.GEARS_RUNTIME` is true), will now construct (and run) the function in the environment.
- Switched meaning of `None` and `False` for `enforce_redgrease`. `False` now means that redgrease requirement should be removed and `None` means "meh, don't care".

# Additional Info
- One (only) test of this was added 😐 
- Tidying up some warnings
- Pointless messing around  with `requirements.resolve_requirements` (needs cleanup)


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [x] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
