### PR TITLE
Fixed broken `dumpexecutions` and `dumpregistrations` for cluster

### DIFF
--- a/src/redgrease/cluster.py
+++ b/src/redgrease/cluster.py
@@ -32,6 +32,8 @@ class RedisCluster(rediscluster.RedisCluster):
             "RG.PYSTATS": "all-nodes",
             "RG.PYDUMPREQS": "random",
             "RG.REFRESHCLUSTER": "all-nodes",
+            "RG.DUMPEXECUTIONS": "random",
+            "RG.DUMPREGISTRATIONS": "random",
         },
     }
 


### PR DESCRIPTION
# Pull Request Overview:
Closing #103 

# Main Changes:
- Configured `cluster.RedisCluster.NODE_FLAGS` to set both "RG.DUMPEXECUTIONS" and "RG.DUMPREGISTRATIONS" to execute on a "random" shard.


# Additional Info
Simple as that


# Checklist
(Check those that apply, just so we know)
## Testing
- [x] Testing : Ad-hoc/manual
- [x] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [x] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
