### PR TITLE
Documentation of runtime

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -12,6 +12,125 @@ Advanced Concepts
 Redgrease Extras Options
 ------------------------
 
+It is always recommendede to install either the redgrease package with either ``redgrease[client]``, ``redgrease[cli]`` or ``redgrease[all]`` package opthions on your clients. 
+
+However for the RedisGears server runtime, you may want to be more prudent with what you install. Therefore, RedGrease strives to give you visibility and control of control of how much of RedGrease you want to install on on your RedisGear server.
+
+For the server you may want to consider these different options:
+
+- ``redgrease[runtime]``
+
+    This is the default and recommended package is to install on your server as this gives you access to every runtime feature in RedGrease, including all the :ref:`gearfun` constructs, the :ref:`red_commands`, as well as the :ref:`runtime`.
+
+    This is what :meth:`.Gears.pyexecute` is going to automatically assume for you when you pass any dynamic :ref:`gearfun` to it, or if you set the ``enforce_redgrease`` argment to eiter ``True`` or just a verison string (e.g. ``"0.3.12"``).
+
+    This option installs all the dependecies that are needed for any of the RedGrease runtime features, but none of the dependecies that are only required for the RedGrease client features. 
+
+- ``redgrease``
+
+    You can also install just the bare ``redgrease`` package without any dependecies. This limits the RedGrease functionalities that you can use to the ones provided by the :ref:`adv_extras_cleanmod`. 
+
+    Most notably this will prevent you from using the :ref:`red_commands`.
+
+    To enforce this option, ensure that any calls to :meth:`.Gears.pyexecute` explicitly set the ``enforce_redgrease`` argument to ``"redgrease"`` (without extras). Version qualifiers are supported (e.g. ``"redgrease>0.3"``).
+
+- Nothing
+
+   Yes, In some cases RedGrease may be of value even if it is **not** installed in the RedisGears runtime environment. If your are only executing GearFunctions by :ref:`exe_gear_function_file`, and the script itself is either:
+
+      **A.** Not importing ``redgrease`` at all (obviously), or 
+
+      **B.** Only using explictly imported :ref:`runtime`, I.e. only importing RedGrease with::
+        
+            from redgrease.runtime import ...
+
+    If this is the case, you can enforce that RedGrease is **not** added to the runtime requirements at all by ensuring that any calls to :meth:`.Gears.pyexecute` explicitly set the ``enforce_redgrease`` argument to ``False``. This option will not add any redgrease requirement to the function and simply ignore any explicit runtime imports.
+
+    .. Note::
+    
+        This only applies to explcit imports of symbols in the :mod:`runtime` module, and not to imports of the moule itself.
+
+        I.e, imports of the form::
+
+            from redgrease.runtime import GB, hashtag
+
+        Or::
+
+            from redgrease.runtime import *
+
+        But not::
+
+            import redgrease.runtime
+
+        Nor::
+
+            from redgrease import GB, hashtag
+
+
+
+Dependency Packages per Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The dependecies of the different extras options are as follows:
+
+- ``redgrease``
+
+    - Clean. No dependencies. See :ref:`adv_extras_cleanmod` for a list of RedGrease modules that can be used.
+
+- ``redgrease[runtime]``
+
+    - `attrs <https://pypi.org/project/attrs/>`_ - This dependency may be removed in future versions.
+    - `cloudpickle <https://pypi.org/project/cloudpickle/>`_ - This dependency may be replaced with `dill <https://pypi.org/project/dill/>`_ in future versions.
+    - `redis <https://pypi.org/project/redis/>`_
+    - `packaging <https://pypi.org/project/packaging/>`_ - This dependency may be moved to the ``client`` extra in future versions.
+    - `wrapt <https://pypi.org/project/wrapt/>`_  - This dependency may be removed in future versions.
+
+- ``redgrease[client]`` 
+
+    - All the dependecies of ``redgrease[runtime]``, plus
+    - `typing-extensions <https://pypi.org/project/typing-extensions/>`_
+    - `redis-py-cluster <https://pypi.org/project/redis-py-cluster/>`_ - This dependency may be moved to a new ``cluster`` extra in future versions.
+
+.. - ``redgrease[client,cluster]`` - All the dependecies of `client`, plus
+..     - `redis-py-cluster <https://pypi.org/project/redis-py-cluster/>`_
+
+- ``redgrease[cli]``
+
+    - All the dependecies of ``redgrease[client]``, plus
+    - `watchdog <https://pypi.org/project/watchdog/>`_ 
+    - `ConfigArgParse <https://pypi.org/project/ConfigArgParse/>`_
+    - `pyyaml <https://pypi.org/project/PyYAML/>`_
+
+.. - ``redgrease[cli,cluster]`` - 
+
+- ``redirease[all]``
+
+    - All dependecies above
+
+
+.. _adv_extras_cleanmod:
+
+"Clean" RedGrease Modules
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "clean" RedGrease modules, that can be used without extra dependencies are:
+
+- :mod:`redgrease.runtime` - Wrapped versions of the built-in runtime functions, but with docstrings and type hints.
+
+- :mod:`redgrease.reader` - GearFunction constructors for the various Reader types.
+
+- :mod:`redgrease.func` - Function decorator for creating ``CommandReader`` functions.
+
+- :mod:`redgrease.utils` - A bunch of helper functions.
+
+- :mod:`redgrease.sugar` - Some trivial sugar for magic strings and such.
+
+- :mod:`redgrease.typing` - A bunch of type helpers, typically not needed to be imported in application code.
+
+- :mod:`redgrease.gears` - The core internals of RedGrease, rarely needed to be imported in application code.
+
+- :mod:`redgreas.hysteresis` - A helper module, specifically for the RedGrease CLI. Not intended to be imported in application code.
+    
 .. _adv_pyver:
 
 Python 3.6 and 3.8+ 

--- a/docs/source/executing.rst
+++ b/docs/source/executing.rst
@@ -22,9 +22,9 @@ There are some subtleties and variations the three types that we'll go through i
     print(result.value)
     print(result.errors)
 
-    .. _exe_gear_function_file:
+    
 
-    .. _exe_gear_function_str:
+.. _exe_gear_function_str:
     
 Raw Function String
 -------------------
@@ -45,6 +45,7 @@ The most basic way of creating and executing Gear Functions is by passing a raw 
 
     You would rarely construct Gear functions this way, but it is fundamentally what happens under the hood for all the other methods of exetution, and corresponds directly to the underlying RedisGears protocol.
 
+.. _exe_gear_function_file:
 
 Script File Path
 ----------------
@@ -65,36 +66,21 @@ A more practical way of defining Gear Functions is by putting them in a separate
 These scripts may be plain vanilla RedisGears functions that only use the :ref:`built-in runtime functions <runtime>`, and does not import `redgrease` or use any of its features. 
 In this case the `redgrease` package does not need to be installed on the runtime.
 
-If the function is importing and using any RedGrease construct from the ``redgreas`` package, then when calling :meth:`redgrease.Gears.pyexecute` method, the ``enforce_redgrease`` must be set in order to ensure that the package is installed on the RedisGears runtime.
+If the function is importing and using any RedGrease construct from the ``redgrease`` package, then when calling :meth:`redgrease.Gears.pyexecute` method, the ``enforce_redgrease`` must be set in order to ensure that the package is installed on the RedisGears runtime.
 
 In most cases you would just set it to ``True`` to get the latest stable RedGrease runtime package, but you may specify a specific version or even redpository.
 
-A notable special case is when functions in the script are only importing RedGrease modules that do not require any 3rd party dependencies. 
-If this is the case then you may want to set `enforce_redgrease="redgrease"` (without the extras `"[runtime]"`), when calling :meth:`redgrease.Gears.pyexecute`, as this is a version of redgrease without any external dependencies. 
+A notable special case is when functions in the script are only importing RedGrease modules that do not require any 3rd party dependencies (see list in the :ref:`adv_extras` section). 
+If this is the case then you may want to set ``enforce_redgrease="redgrease"`` (without the extras `"[runtime]"`), when calling :meth:`redgrease.Gears.pyexecute`, as this is a version of redgrease without any external dependencies. 
+
+Another case is when you are only using explicitly imported :ref:`runtime` (e.g. ``from redgrease.runtime import GB, logs, execute``) , and nothing else, as you in this case do not need any version of RedGrease on your RedisGears server runtime. In this case you can actually set ``enforce_redgrease=False``.
+
+More details about the various runtime installation options, which modules and functions are impacted, as well as the respective 3rd party dependecies can be found in the :ref:`adv_extras` sectoin.
 
 .. Note::
 
     By default all Gear functions run in a shared runtime environment, and as a consequence all requirements / dependencies from differnt Gear functions are all installed in the same Python enviornment.
 
-
-The "clean" RedGrease modules, whithout dependencies are:
-
-- :mod:`redgrease.runtime` - Wrapped versions of the built-in runtime functions, but with docstrings and type hints.
-
-- :mod:`redgrease.reader` - GearFunction constructors for the various Reader types.
-
-- :mod:`redgrease.func` - Function decorator for creating ``CommandReader`` functions.
-
-- :mod:`redgrease.utils` - A bunch of helper functions.
-
-- :mod:`redgrease.sugar` - Some trivial sugar for magic strings and such.
-
-- :mod:`redgrease.typing` - A bunch of type helpers, typically not needed to be imported in application code.
-
-- :mod:`redgrease.gears` - The core internals of RedGrease, rarely needed to be imported in application code.
-
-- :mod:`redgreas.hysteresis` - A helper module, specifically for the RedGrease CLI. Not intended to be imported in application code.
-    
 
 .. _exe_gear_function_obj:
 

--- a/docs/source/gearfunctions.rst
+++ b/docs/source/gearfunctions.rst
@@ -2,13 +2,13 @@
 
 .. _gearfun:
 
-GearFunctions
-=============
+GearFunction
+============
 
 .. _gearfun_readers:
 
-Readers
--------
+Reader
+------
 
 .. include :: wip.rst
 

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -6,23 +6,54 @@
 Builtin Runtime Functions
 =========================
 
-.. include :: wip.rst
+The RedisGears Python server runtime automatically expose a number of functions into the scope of any Gear functions it is executing.
+These "builtin" runtime functions can be used in Gear Functions without importing any module or package:
 
-You can load the default redisgears symbols (e.g. `GearsBuilder`, `GB`, `atomic`, `execute`, `log` etc) from the `redgrease.runtime` package. 
+   - :ref:`runtime_gearsbuilder`
+   - :ref:`runtime_execute`
+   - :ref:`runtime_atomic`
+   - :ref:`runtime_configGet`
+   - :ref:`runtime_gearsConfigGet`
+   - :ref:`runtime_hashtag`
+   - :ref:`runtime_log`
+..   - :ref:`runtime_gearsFuture`
 
-During development this will give you auto-completion and type hints
-In the Redis Gears Python runtime, all the `redgrease.runtime` are mapped directly to the normal ones wihtout side-effects.
+RedGrease also expose, wrapped versions of these very same functions that, for the most part, behave exactly like the originals, but require you to import them, either from the top level ``redgrease`` package, or from the ``redgrease.runtime`` module.
 
-``
-from redgrease import GearsBuilder, log, atomic, execute
-``
+But if these are the same, why would you bother with them?
 
-This will enable auto completion in your IDE, for Redis Gears stuff. Example from Redis Gears Introduction:
+The main reason to use the RedGrease versions, is that they aid during develpent by enabling most Integrated Development Environment (IDE) access to the doc-strings and type-annotations that the RedGrease versions are providing. 
 
-RedGrease's `runtime` package will detect when it is imported inside an actual RedisGears Python runtime environment and will then load the default redis gears symbols, avoiding conflict with the built-in Redis Gears Python environment.
-If it is loaded outside a Redis Gears Python runtime environment, i.e. a development environment, the `redgrease.runtime` package will instead load placeholder symbols with decent (hopefully) doc-strings and type-hints, for easier development.
+This alone can help greatly in developing gears faster (e.g. through auto-complete) and with less errors (e.g. with type checking).
 
-It is possible to load all symbols, using `*`, but it's generally not a recomended practice.
+.. note::
+
+   If you are **only** using  hese wrapped runtime functions in your Gear Functions, and **no other** RedGrease features, then you actually don't need RedGrease to be installed on the RedisGears server runtime. Explicitly setting ``enforce_redgrease`` argument to ``False`` when executing a function script with to :meth:`.Gears.pyexecute`,  will not add any redgrease requirement to the function and simply ignore any explicit runtime imports.
+
+   The section, :ref:`adv_extras` , goes deeper into the detals of the various RedGrease extras options, and their imlications.
+
+Another reason to use the functions from RedGrease :mod:`runtime`, is that it contains some slightly enhanced variants of the defaults, like for example, the :ref:`runtime_log`, or have alternative versions, like :ref:`runtime_hashtag3`. 
+
+And if you are going to use other RedGrease features, then you will have to load the top level ``redgrease`` namespace anyway, which automatically expose the runtime functions.
+
+
+The RedGrease runtime functions can be imported in a few ways:
+
+- Directly from the package top-level, e.g::
+
+   from redgrease import GearsBuilder, log, atomic, execute
+
+- Explicitly from the :mod:`redgrease.runtime` module::
+
+   from redgrease.runtime import GearsBuilder, log, atomic, execute
+
+- By importing the :mod:`redgrease.runtime` module::
+
+   import redgrease.runtime
+
+
+It is possible to load all symbols, using ``*``, although it's generally not a recomended practice, particularly not for the top level ``redgrease`` package.
+
 
 
 .. _runtime_gearsbuilder:
@@ -30,16 +61,74 @@ It is possible to load all symbols, using `*`, but it's generally not a recomend
 GearsBuilder
 ------------
 
+The :class:`.runtime.GearsBuilder` (as well as its short-form alias ``GB``), behaves exactly like the default version, with a couple of exceptions:
+
+#. It has a property  ``gearfunction`` which gives access to the constructed :ref:`gearfun` object at that that point in the builder pipeline.
+
+#. Any additional arguments passed to its constructor, will be passed as defaults to the :meth:`run() <redgrease.gears.PartialGearsFunction.run>` or  :meth:`register() <redgrease.gears.PartialGearsFunction.register>` action that terminates the build.
+
+.. note::
+
+   As withe The :class:`GearsBuilder` objects are mutable with respect to the :ref:`operations`, whereas :ref:`gearfun` objects are immutable and returns a new function when an operation is applied. 
+
+   This means that::
+
+      fun = GearsBuilder()
+      fun.map(...)
+      fun.aggreagateby(...)
+
+   Creates one single function equivalent to::
+
+      fun = KeysReader().map(...).aggreagateby(...)
+
+   Whereas::
+
+      sad = KeysReader()
+      sad.map(...)
+      sad.aggreagateby(...)
+
+   Creates three functions; One named ``sad`` that is just the :ref:`gearfun_reader_keysreader`, one which is ``sad`` with a :ref:`op_map` and one which is ``sad`` with a :ref:`op_aggregateby`. The latter two functions are also not bound to any varibles in this example.
+
+
+``GearsReader`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.GearsBuilder
+
+
+
 .. _runtime_execute:
 
 execute
 -------
 
-Example
-~~~~~~~
-Below is an example::
+RedGrease's version of :func:`.runtime.execute` behaves just like the default.
 
-   from redgrease.runtime import GearsBuilder, execute
+This function executes an arbitrary Redis command.
+
+.. note::
+
+   For more information about Redis commands refer to:
+
+      - `Redis commands <https://redis.io/commands>`_
+
+Arguments
+
+   - command : the command to execute
+   - args : the command's arguments
+
+Example::
+
+   from redgrease import execute
+
+   # Pings the server (reply should be 'PONG')
+   reply = execute('PING')
+
+In most cases, a more convenient approach is to use :ref:`red_commands` to execute Redis Commands inside Gear Functions.
+
+Longoer Example::
+
+   from redgrease import GearsBuilder, execute
 
    def age(x):
       ''' Extracts the age from a person's record '''
@@ -59,34 +148,147 @@ Below is an example::
    gb.foreach(cas)
    gb.register('person:*')
 
+   
+``execute`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: redgrease.runtime.execute
+
+
+
 .. _runtime_atomic:
 
 atomic
 ------
+
+RedGrease's version of :func:`.runtime.atomic` behaves just like the default.
+
+Atomic provides a `context manager <https://book.pythontips.com/en/latest/context_managers.html>`_  that ensures that all operations in it are executed atomically by blocking the main Redis process.
+
+Example::
+
+   from redgrease import atomic, GB, hashtag
+
+   # Increments two keys atomically
+   def transaction(_):
+      with atomic():
+         execute('INCR', f'{{{hashtag()}}}:foo')
+         execute('INCR', f'{{{hashtag()}}}:bar')
+
+   gb = GB('ShardsIDReader')
+   gb.foreach(transaction)
+   gb.run()
+
+
+``atomic`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.atomic
+
+
 
 .. _runtime_configGet:
 
 configGet
 ---------
 
+RedGrease's version of :func:`.runtime.configGet` behaves just like the default.
+
+This function fetches the current value of a RedisGears `configuration <https://oss.redislabs.com/redisgears/1.0/configuration.html>`_ options. 
+
+Example::
+
+   from redgrease import configGet
+
+   # Gets the current value for 'ProfileExecutions'
+   foo = configGet('ProfileExecutions')
+
+``configGet`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.configGet
+
+
+
 .. _runtime_gearsConfigGet:
 
 gearsConfigGet
 --------------
+
+RedGrease's version of :func:`.runtime.gearsConfigGet` behaves just like the default.
+
+This function fetches the current value of a RedisGears `configuration <https://oss.redislabs.com/redisgears/1.0/configuration.html>`_ options, and returns a defualt value if that key does not exist.
+
+Example::
+
+   from redgrease import gearsConfigGet
+
+   # Gets the 'foo' configuration option key and defaults to 'bar'
+   foo = gearsConfigGet('foo', default='bar')
+
+
+``gearsConfigGet`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.gearsConfigGet
+
+
 
 .. _runtime_hashtag:
 
 hashtag
 -------
 
+RedGrease's version of :func:`.runtime.hashtag` behaves just like the default.
+
+This function returns a hashtag that maps to the lowest hash slot served by the local engine's shard. Put differently, it is useful as a hashtag for partitioning in a cluster. 
+
+``hashtag`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.hashtag
+
+
+
+.. _runtime_hashtag3:
+
+hashtag3
+--------
+
+This function, :func:`.runtime.hashtag3`, is not part of the default RedisGears runtime scope, and is introduced by RedGrease.
+It is a slightly modified version of version of :func:`.runtime.hashtag` but adds enclosing curly braces (``"{"`` and ``"}"``) to the hashtag, so it can be used directly inside Python `f-strings <https://realpython.com/python-f-strings/>`_.
+
+``hashtag3`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.hashtag3
+
+
+
 .. _runtime_log:
 
 log
 ---
 
-.. _runtime_gearsFuture:
+RedGrease's version of :func:`.runtime.log` behaves almost like the default.
+It prints a message to Redis' log, but forces the the argment to a string before logging it. 
 
-gearsFuture
------------
+(The built in default throws an error if the argument is not a string.)
+
+Example::
+
+   from redgrease import GB, log
+
+   # Dumps every datum in the DB to the log for "debug" purposes
+   GB().foreach(lambda x: log(str(x), level='debug')).run()
+
+
+``log`` API Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: redgrease.runtime.log
+
+
+Now we are finally ready to start building some Gear Functions.
 
 .. include :: footer.rst

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -89,6 +89,19 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
             )
         )
 
+    @property
+    def gearfunction(self):
+        """The "open" GearFunction object at this step in the pipeline.
+
+        This GearFunction object can be extender upon, independently from the
+        GearsBuilder.
+
+        Returns:
+            redgrease.gears.PartialGearFunction:
+                The current GearFunction object.
+        """
+        return self._function
+
     def run(
         self,
         arg: str = None,  # TODO: This can also be a Python generator
@@ -474,11 +487,9 @@ def hashtag3() -> str:
     For example, if `hashtag()` generates "06S", then `hashtag3' gives "{06S}".
 
     This is useful for creating slot-specific keys using f-strings,
-    inside gear functions, as the braces are already escaped. Example:
+    inside gear functions, as the braces are already escaped. Example::
 
-    .. code-block:: python
-
-        redgrease.cmd.set(f"{hastag}",  some_value)
+        redgrease.cmd.set(f"{hashtag3()}",  some_value)
 
     Returns:
         str:


### PR DESCRIPTION
# Pull Request Overview:
Added the "runtime" section of the Documentation.

# Main Changes:
The section.

# Additional Info
Probably littered with spelling errors.


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
