### PR TITLE
Renamed PartialGearFunction to OpenGearFunction  

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ relevant_usr_fields = {
     "permissions": redgrease.utils.list_parser(str),
 }
 
-# # Partial Gear function
+# # "Open" Gear function
 # Extracting a dict for every 'active' user
 active_users = (
     redgrease.KeysOnlyReader()
@@ -205,7 +205,7 @@ active_users = (
     )
     .filter(lambda usr: usr["active"])
 )
-# # Partial Gear function re-use
+# # "Open" Gear function re-use
 # Count the number of active users
 active_user_count = active_users.count()
 

--- a/docs/source/executing.rst
+++ b/docs/source/executing.rst
@@ -120,11 +120,8 @@ The output from the last operation, here :meth:`countby() <redgrease.gears.OpenG
 
 Once an "open" function is terminated with either a :meth:`run() <redgrease.gears.OpenGearFunction.run>`  or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action, it is considered "closed", and it can be executed, but not further extended.
 
-.. note::
-    
-    This "open/closed" terminology should not be confused with "`partial functions <https://en.wikipedia.org/wiki/Partial_function>`_" in mathematics, nor "`partial application <https://en.wikipedia.org/wiki/Partial_application>`_" in computer science, which are completely different concepts. 
-    
-    The terminology is also not explicitly used by RedisLabs in their `RedisGears Function Documentation <https://oss.redislabs.com/redisgears/1.0/functions.html>`_, but it was the most intuitive terminology I could think of to describe how their design of GearsBuilder actually behaves. 
+The :ref:`gearfun` section, goes into more details of these concepts and the different classes of GearFuctions.
+
 
 RedGrease allows for open Gear functions, such as ``key_counter`` to be used as a starting point for other Gear functions, so lets create two "closed" functions from it:
 

--- a/docs/source/executing.rst
+++ b/docs/source/executing.rst
@@ -115,10 +115,10 @@ As an example let's assume, that we have instanitated a Gear client and created 
 
 In this example ``get_keys_by_type`` is our simple "open" Gear function, which groups all the keys by their type ("string", "hash", "stream" etc) , and within each group collects the keys in a set. 
     
-We call it "open" because it has not been "closed" by a :meth:`run() <redgrease.gears.PartialGearFunction.run>` or  :meth:`register() <redgrease.gears.PartialGearFunction.register>` action.
-The output from the last operation, here :meth:`countby() <redgrease.gears.PartialGearFunction.countby>`, can therefore be used as input for a subsequent operations, if we'd like. The chain of operations of the function is "open-ended", if you will.
+We call it "open" because it has not been "closed" by a :meth:`run() <redgrease.gears.OpenGearFunction.run>` or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action.
+The output from the last operation, here :meth:`countby() <redgrease.gears.OpenGearFunction.countby>`, can therefore be used as input for a subsequent operations, if we'd like. The chain of operations of the function is "open-ended", if you will.
 
-Once an "open" function is terminated with either a :meth:`run() <redgrease.gears.PartialGearFunction.run>`  or  :meth:`register() <redgrease.gears.PartialGearFunction.register>` action, it is considered "closed", and it can be executed, but not further extended.
+Once an "open" function is terminated with either a :meth:`run() <redgrease.gears.OpenGearFunction.run>`  or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action, it is considered "closed", and it can be executed, but not further extended.
 
 .. note::
     
@@ -137,7 +137,7 @@ These two new functions, ``get_keys_by_type_dict`` and ``get_commones_type``, bo
 The former function collates the results in a dictionary.
 The latter finds the key-type that is most common in the keyspace.
 
-Note that both functions end with the :meth:`run() <redgrease.gears.PartialGearFunction.run>` action, which indicates that the functions will run as an on-demand batch-job, but also that it is 'closed' and cannot be exteded further. 
+Note that both functions end with the :meth:`run() <redgrease.gears.OpenGearFunction.run>` action, which indicates that the functions will run as an on-demand batch-job, but also that it is 'closed' and cannot be exteded further. 
 
 Let's excute thes functions in some different ways.
 
@@ -161,7 +161,7 @@ The result might look something like:
     :end-before: """
 
 
-If you pass an "open" gear function, like our initial ``get_keys_by_type``,  to :meth:`.Gears.pyexecute`, it will still try its best to execute it, by assuming that you meant to close it with an empty :meth:`run() <redgrease.gears.PartialGearFunction.run>` action in the end:
+If you pass an "open" gear function, like our initial ``get_keys_by_type``,  to :meth:`.Gears.pyexecute`, it will still try its best to execute it, by assuming that you meant to close it with an empty :meth:`run() <redgrease.gears.OpenGearFunction.run>` action in the end:
 
 .. literalinclude:: ../../examples/exe_example.py
     :start-after: # # Method 3
@@ -187,7 +187,7 @@ Another short-form way of running a closed GearFunction is to call its its :meth
     :end-before: # #
     :emphasize-lines: 4
 
-This approach only works with "closed" functions, but works regardless if the function has been closed with the :meth:`run() <redgrease.gears.PartialGearFunction.run>` or :meth:`register() <redgrease.gears.PartialGearFunction.register>` action.
+This approach only works with "closed" functions, but works regardless if the function has been closed with the :meth:`run() <redgrease.gears.OpenGearFunction.run>` or :meth:`register() <redgrease.gears.OpenGearFunction.register>` action.
 
 The result for our specific function might look something like:
 
@@ -201,10 +201,10 @@ The API specification is as follows:
 
 .. _exe_gear_function_obj_on_closing:
 
-Execute directly in :meth:`run() <.PartialGearFunction.run>` or :meth:`register() <.PartialGearFunction.register>`
+Execute directly in :meth:`run() <.OpenGearFunction.run>` or :meth:`register() <.OpenGearFunction.register>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An even more succinct way of executing GearFunction objects is to specify the target connection directly in the action that closes the function. I.e the :meth:`run() <redgrease.gears.PartialGearFunction.run>`  or  :meth:`register() <redgrease.gears.PartialGearFunction.register>` action.
+An even more succinct way of executing GearFunction objects is to specify the target connection directly in the action that closes the function. I.e the :meth:`run() <redgrease.gears.OpenGearFunction.run>`  or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action.
 
 RedGrease has extended these methods with a couple additonal arguments, which are not in the standard RedisGears API:
 
@@ -217,7 +217,7 @@ RedGrease has extended these methods with a couple additonal arguments, which ar
     :end-before: # #
     :emphasize-lines: 4
 
-This approach only works with "closed" functions, but works regardless if the function has been closed with the :meth:`run() <redgrease.gears.PartialGearFunction.run>`  or  :meth:`register() <redgrease.gears.PartialGearFunction.register>` action.
+This approach only works with "closed" functions, but works regardless if the function has been closed with the :meth:`run() <redgrease.gears.OpenGearFunction.run>`  or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action.
 
 The result for our specific function should be identical to when we ran the function using :ref:`pyexecute <exe_gear_function_obj_pyexcute>`:
 

--- a/docs/source/gearfunctions.rst
+++ b/docs/source/gearfunctions.rst
@@ -23,27 +23,34 @@ These function objects can be dynamically constructed in either your application
 
 These are responsible for reading data from different sources into records, either in batch on-demand or when some event occurs. 
 
-GearFunctions are created by "attaching" :ref:`operations`, such as :ref:`op_map`, :ref:`op_groupby`, :ref:`op_aggregate` etc, to a :ref:`gearfun_builder`, a:ref:`gearfun_readers`  or another GearFunction.
+GearFunctions are created by "applying" :ref:`operations`, such as :ref:`op_map`, :ref:`op_groupby`, :ref:`op_aggregate` etc, to either any of the :ref:`gearfun_readers`, a :ref:`gearfun_builder`,  or some other GearFunction.
 
-With the exception of the :ref:`gearfun_builder`, "attaching" an operation on a GearFunction, doesn't actually modify it, but instead creates a new function with that operation added. 
+With the exception of the :ref:`gearfun_builder`, "applying" an operation on a GearFunction, doesn't actually modify it, but instead creates a new function with that operation added. 
 
-All Gear functions therefore consists of a chains of zero or more :ref:`operations`, with some reader at the begining. 
+All Gear functions therefore consists of a chain of zero or more :ref:`operations`, with some reader at the begining. 
 
-Some Readers allow for some additional reader-specific operations, that can be invoked ony as as the first operation.
-
-Some Readers support both "batch-mode" and "event-mode", but some only support one of the modes.
+Some of the Reader types have additional reader-specific operations, that can only be "applied" as as their first operation.
 
 Gear functions are "terminated" by either one of two special :ref:`op_action`. Either :ref:`op_action_run`, for immediate "batch-mode" execution, or :ref:`op_action_register`, for registering the function for "event-mode" execution.
 
-GearFunctions that **have not** been "terminated" by any :ref:`op_action`, are referred to as :ref:`gearfun_open`, as they **can be extended** with more operations, creating new GearFunctions. 
+Some Readers support both "batch-mode" and "event-mode", but some only support one of the modes.
 
-GearFunctions that **have** been "terminated" by any :ref:`op_action`, are referred to as :ref:`gearfun_closed`, as they **cannot be extended** with more operations, creating new GearFunctions, but they can be executed. 
+GearFunctions that **have not** been "terminated" by either of the :ref:`op_action`, are referred to as an :ref:`gearfun_open`, as they **can be extended** with more operations, creating new GearFunctions. 
+
+GearFunctions that **have** been "terminated" by either of the :ref:`op_action`, are referred to as a :ref:`gearfun_closed`, as they **cannot be extended** with more operations, creating new GearFunctions, but they can be executed. 
+
+.. note::
+    
+    This "open/closed" terminology is not explicitly used by RedisLabs in their `RedisGears Function Documentation <https://oss.redislabs.com/redisgears/1.0/functions.html>`_, but it was the most intuitive terminology I could think of, to describe how their design of GearsBuilder actually behaves. 
+
+    Early versions of RedGrease used the term "partial" instead of "open". This was deemed a bit confusing, because "`partial functions <https://en.wikipedia.org/wiki/Partial_function>`_" is a very specific, but completely different, thing in mathematics. It was also sometimes confused with "`partial application <https://en.wikipedia.org/wiki/Partial_application>`_", which in computer science is yet another completely different (but powerful) concept. 
+
 
 Every :ref:`gearfun_open`, including the :ref:`gearfun_builder`, implement the default set of :ref:`operations`.
 
-When a GearFuctions is executed, the Reader reads its data, and pass each record to its first operation, which modifies, filters or aggregates the records into some new output records, which in turn are passed to the next operation and so on, until the last operation.
+When a GearFuctions is executed, the Reader reads its data, and pass each record to its first operation, which modifies, filters or aggregates these records into some new output records, which in turn are passed to the next operation and so on, until the last operation.
 
-The output of the final operation is then either, returned to the caller if it was a "batch-mode" execution **and** ``unblocking`` was not set to ``True`` in :meth:`.Gears.pyexecute`, or stored for later retrieval oterwise.
+The output of the final operation is then either, returned to the caller if it was a "batch-mode" execution **and** ``unblocking`` was not set to ``True`` in :meth:`.Gears.pyexecute`, or stored for later retrieval otherwise.
 
 
 .. _gearfun_open:
@@ -53,7 +60,7 @@ OpenGearFunction
 
 You would never instatiate a :class:`.gears.OpenGearFunction` yourself, but all "open" :ref:`GearFuctions <gearfun>` that has not yet been "closed" with the :ref:`op_action_run` or :ref:`op_action_register` :ref:`op_action`, inherits from this class. 
 
-It is this class that under the hood is responsible for "attaching" :ref:`opertations` and :ref:`Actions <op_action>` and creating new GearFuctions.
+It is this class that under the hood is responsible for "applying" :ref:`operations` and :ref:`Actions <op_action>`, and thus creating new GearFuctions.
 
 This includes both the :class:`.runtime.GearsBuilder` as well as the :ref:`gearfun_readers`:
 

--- a/docs/source/gearfunctions.rst
+++ b/docs/source/gearfunctions.rst
@@ -48,17 +48,17 @@ The output of the final operation is then either, returned to the caller if it w
 
 .. _gearfun_open:
 
-PartialGearFunction 
+OpenGearFunction 
 ~~~~~~~~~~~~~~~~~~~
 
-You would never instatiate a :class:`.gears.PartialGearFunction` yourself, but all "open" :ref:`GearFuctions <gearfun>` that has not yet been "closed" with the :ref:`op_action_run` or :ref:`op_action_register` :ref:`op_action`, inherits from this class. 
+You would never instatiate a :class:`.gears.OpenGearFunction` yourself, but all "open" :ref:`GearFuctions <gearfun>` that has not yet been "closed" with the :ref:`op_action_run` or :ref:`op_action_register` :ref:`op_action`, inherits from this class. 
 
 It is this class that under the hood is responsible for "attaching" :ref:`opertations` and :ref:`Actions <op_action>` and creating new GearFuctions.
 
 This includes both the :class:`.runtime.GearsBuilder` as well as the :ref:`gearfun_readers`:
 
 
-.. autoclass:: redgrease.gears.PartialGearFunction()
+.. autoclass:: redgrease.gears.OpenGearFunction()
     :members:
     :member-order: bysource
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -132,7 +132,7 @@ The RedGrease package provides a number of functionalities that facilitates writ
 
     Inspired by the "remote builders" of the official `redisgears-py <https://github.com/RedisGears/redisgears-py>`_ client, but with some differences, eg:
 
-    * Supports reuse of 'partial' Gear functions.
+    * Supports reuse of 'open' (incomplete) Gear functions.
 
     * Can be created without a Redis connection.
 

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -258,7 +258,7 @@ The :class:`.runtime.GearsBuilder` (as well as its short-form alias ``GB``), beh
 
 #. It has a property  ``gearfunction`` which gives access to the constructed :ref:`gearfun` object at that that point in the builder pipeline.
 
-#. Any additional arguments passed to its constructor, will be passed as defaults to the :meth:`run() <redgrease.gears.PartialGearFunction.run>` or  :meth:`register() <redgrease.gears.PartialGearFunction.register>` action that terminates the build.
+#. Any additional arguments passed to its constructor, will be passed as defaults to the :meth:`run() <redgrease.gears.OpenGearFunction.run>` or  :meth:`register() <redgrease.gears.OpenGearFunction.register>` action that terminates the build.
 
 .. note::
 

--- a/examples/Demo.ipynb
+++ b/examples/Demo.ipynb
@@ -643,7 +643,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Partial RedGrease GearFunction objects can be composed and reused"
+    "Open RedGrease GearFunction objects can be composed and reused"
    ]
   },
   {
@@ -676,7 +676,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can dynamically create parameterized partial RedGrease GearFunctions in normal functions"
+    "You can dynamically create parameterized open RedGrease GearFunctions in normal functions"
    ]
   },
   {
@@ -719,7 +719,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "### As a partial function, i.e. without a closing 'run' or 'register' (Run is inferred)\n",
+    "### As an open function, i.e. without a closing 'run' or 'register' (Run is inferred)\n",
     "annotation_cnt = cluster.gears.pyexecute(instance_annotations().count())\n",
     "\n",
     "print(f\"Total number of annotations: {annotation_cnt}\\n\")"
@@ -734,7 +734,7 @@
     "#> Directly from a closed GearFunction, using the `on`-method\n",
     "avg_square_size = square_images.map(lambda sq: sq['width']).avg().run()\n",
     "\n",
-    "print(f\"Look, it aint no PartialGearFunction no more. it is a {type(avg_square_size)}\")\n",
+    "print(f\"Look, it aint no OpenGearFunction no more. it is a {type(avg_square_size)}\")\n",
     "avg_square_size.on(cluster)"
    ]
   },

--- a/examples/counting_users.py
+++ b/examples/counting_users.py
@@ -9,7 +9,7 @@ relevant_usr_fields = {
     "permissions": redgrease.utils.list_parser(str),
 }
 
-# # Partial Gear function
+# # Open Gear function
 # Extracting a dict for every 'active' user
 active_users = (
     redgrease.KeysOnlyReader()
@@ -21,7 +21,7 @@ active_users = (
     )
     .filter(lambda usr: usr["active"])
 )
-# # Partial Gear function re-use
+# # Open Gear function re-use
 # Count the number of active users
 active_user_count = active_users.count()
 

--- a/examples/mixed_features.py
+++ b/examples/mixed_features.py
@@ -6,7 +6,7 @@ relevant_usr_fields = {
     "permissions": redgrease.utils.list_parser(str),
 }
 
-# Partial Gear function, w. default run param:
+# Open Gear function, w. default run param:
 active_users = (
     redgrease.KeysOnlyReader("user:*")
     .map(lambda key: redgrease.cmd.hmget(key, *relevant_usr_fields.keys()))
@@ -17,7 +17,7 @@ active_users = (
     )
     .filter(lambda usr: usr["active"])
 )
-# Partial Gear function re-use:
+# Open Gear function re-use:
 active_user_count = active_users.count()
 
 all_issued_permissions = active_users.flatmap(lambda usr: usr["permissions"]).distinct()

--- a/src/redgrease/__init__.py
+++ b/src/redgrease/__init__.py
@@ -33,7 +33,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 import sys
 
 from .func import command, trigger
-from .gears import ClosedGearFunction, GearFunction, PartialGearFunction
+from .gears import ClosedGearFunction, GearFunction, OpenGearFunction
 from .reader import (
     CommandReader,
     GearReader,
@@ -50,7 +50,7 @@ __all__ = [
     "trigger",
     "ClosedGearFunction",
     "GearFunction",
-    "PartialGearFunction",
+    "OpenGearFunction",
     "FailurePolicy",
     "KeyType",
     "LogLevel",

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -451,7 +451,7 @@ class Gears:
 
                     * Python version must match the Gear runtime.
 
-                    * If the function is not "closed" with a :meth:`run <.PartialGearFunction.run>` or :meth:`register <.PartialGearFunction.register>` operation, an ``run()`` operation without additional arguments will be assumed, and automatically added to the function to close it.
+                    * If the function is not "closed" with a :meth:`run <.OpenGearFunction.run>` or :meth:`register <.OpenGearFunction.register>` operation, an ``run()`` operation without additional arguments will be assumed, and automatically added to the function to close it.
 
                     * The default for ``enforce_redgrease`` is ``True``.
 

--- a/src/redgrease/gearialization.py
+++ b/src/redgrease/gearialization.py
@@ -147,7 +147,7 @@ def get_function_string(
         ctx["requirements"] = gear_function.requirements
         ctx["enforce_redgrease"] = True
 
-        if isinstance(gear_function, redgrease.gears.PartialGearFunction):
+        if isinstance(gear_function, redgrease.gears.OpenGearFunction):
             # If the function isn't closed with either 'run' or 'register'
             # we assume it is meant to be closed with a 'run'
             gear_function = gear_function.run()

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -141,12 +141,13 @@ class Reader(Operation):
     Attributes:
         reader (str):
             The type of reader (https://oss.redislabs.com/redisgears/readers.html)
-                - 'KeysReader'
-                - 'KeysOnlyReader'
-                - 'StreamReader'
-                - 'PythonReader'
-                - 'ShardsIDReader'
-                - 'CommandReader'
+
+                - ``"KeysReader"``
+                - ``"KeysOnlyReader"``
+                - ``"StreamReader"``
+                - ``"PythonReader"``
+                - ``"ShardsIDReader"``
+                - ``"CommandReader"``
 
         defaultArg (str):
             Argument that the reader may need. These are usually a key's name, prefix,
@@ -250,11 +251,11 @@ class Run(Operation):
             convertToStr (bool, optional):
                 When `True`, adds a map operation to the flow's end that stringifies
                 records.
-                Defaults to True.
+                Defaults to ``True``.
 
             collect (bool, optional):
                 When `True`, adds a collect operation to flow's end.
-                Defaults to True.
+                Defaults to ``True``.
         """
         super().__init__(**kwargs)
         self.arg = arg
@@ -270,7 +271,7 @@ class Run(Operation):
 
         Returns:
             ClosedGearFunction:
-                A closed Gear batch function that is ready to run on a Gears cluster.
+                A closed Gear batch function that is ready to run in RedisGears.
         """
         import cloudpickle
 
@@ -327,26 +328,31 @@ class Register(Operation):
                 Defaults to '*'.
 
             convertToStr (bool, optional):
-                When `True` adds a map operation to the flow's end that stringifies
+                When ``True`` adds a map operation to the flow's end that stringifies
                 records.
-                Defaults to True.
+                Defaults to ``True``.
 
             collect (bool, optional):
-                When True adds a collect operation to flow's end.
-                Defaults to False.
+                When ``True`` adds a collect operation to flow's end.
+                Defaults to ``False``.
 
             mode (str, optional):
                 The execution mode of the function.
                 Can be one of::
 
-                - 'async' : Execution will be asynchronous across the entire cluster.
+                - ``"async"``:
 
-                - 'async_local' : Execution will be asynchronous and restricted to
-                    the handling shard.
+                    Execution will be asynchronous across the entire cluster.
 
-                - 'sync' : Execution will be synchronous and local
+                - ``"async_local"``:
 
-                Defaults to `redgrease.TriggerMode.Async` ("async")
+                    Execution will be asynchronous and restricted to the handling shard.
+
+                - ``"sync"``:
+
+                    Execution will be synchronous and local
+
+                Defaults to `redgrease.TriggerMode.Async` (``"async"``)
 
             onRegistered (Callback, optional):
                 A function callback that's called on each shard upon function
@@ -372,8 +378,8 @@ class Register(Operation):
 
         Returns:
             ClosedGearFunction:
-                A closed Gear event function that is ready to be regisetered on a
-                Gears cluster.
+                A closed "event-mode" Gear function that is ready to be regisetered on a
+                RedisGears system.
         """
         import cloudpickle
 
@@ -526,7 +532,7 @@ class Filter(Operation):
             op (redgrease.typing.Filterer):
                 Function to apply on the input records, to decide which ones to keep.
                 The function must take one argument as input (input record) and
-                return a bool. The input records evaluated to `True` will be kept as
+                return a bool. The input records evaluated to ``True`` will be kept as
                 output records.
         """
         super().__init__(**kwargs)
@@ -1083,7 +1089,8 @@ class Sort(Operation):
 
     Attributes:
         reverse (bool):
-            Defines if the sorting orded is descending (`True`) or ascendinng (`False`).
+            Defines if the sorting orded is descending (``True``) or ascendinng
+            (``False``).
     """
 
     def __init__(self, reverse: bool = True, **kwargs) -> None:
@@ -1092,7 +1099,7 @@ class Sort(Operation):
         Args:
             reverse (bool, optional):
                 Sort in descending order (higer to lower).
-                Defaults to True.
+                Defaults to ``True``.
         """
         super().__init__(**kwargs)
         self.reverse = reverse
@@ -1311,8 +1318,9 @@ class GearFunction(Generic[T]):
 
         Returns:
             str:
-                Either 'KeysReader', 'KeysOnlyReader', 'StreamReader', 'PythonReader',
-                    'ShardsIDReader', 'CommandReader' or None (If no reader is defined).
+                Either ``"KeysReader"``, ``"KeysOnlyReader"``, ``"StreamReader"``,
+                ``"PythonReader"``, ``"ShardsIDReader"``, ``"CommandReader"`` or
+                ``None`` (If no reader is defined).
         """
         if isinstance(self.operation, Reader):
             return self.operation.reader
@@ -1329,7 +1337,7 @@ class GearFunction(Generic[T]):
 
         Returns:
             bool:
-                `True` if the function supports batch mode, `False` if not.
+                ``True`` if the function supports batch mode, ``False`` if not.
         """
         return self.reader in [
             sugar.ReaderType.KeysReader,
@@ -1346,7 +1354,7 @@ class GearFunction(Generic[T]):
 
         Returns:
             bool:
-                `True` if the function supports event mode, `False` if not.
+                ``True`` if the function supports event mode, ``False`` if not.
         """
         return self.reader in [
             sugar.ReaderType.KeysReader,
@@ -1359,8 +1367,8 @@ class ClosedGearFunction(GearFunction[T]):
     """Closed Gear functions are GearsFunctions that have been "closed" with a
     :ref:`op_action_run` action or a :ref:`op_action_register` action.
 
-    Closed Gear functions cannot add more :ref:`operations`, but can be executed in a
-    Redis Gears cluster.
+    Closed Gear functions cannot add more :ref:`operations`, but can be executed in
+    RedisGears.
     """
 
     def __init__(
@@ -1382,7 +1390,7 @@ class ClosedGearFunction(GearFunction[T]):
         replace: bool = None,
         **kwargs,
     ):
-        """Execute the function on a Redis Gear server / cluster.
+        """Execute the function on a RedisGears.
         This is equivalent to passing the function to `Gears.pyexecute`
 
         Args:
@@ -1391,7 +1399,7 @@ class ClosedGearFunction(GearFunction[T]):
 
             unblocking (bool, optional):
                 Execute function unblocking, i.e. asyncronous.
-                Defaults to False.
+                Defaults to ``False``.
 
             requirements (Iterable[str], optional):
                 Additional requirements / dedpendency Python packages.
@@ -1419,9 +1427,9 @@ class ClosedGearFunction(GearFunction[T]):
 
             # If we get an error because the trigger already is registered,
             # then we check the 'replace' argument for what to do:
-            # - `replace is None` : Re-raise the error
-            # - `replace is False` : Ignore the error
-            # - `replace is True` : Unregister the previous and re-register the new
+            # - `replace is ``None``` : Re-raise the error
+            # - `replace is ``False``` : Ignore the error
+            # - `replace is ``True``` : Unregister the previous and re-register the new
             if replace is None or "trigger" not in self.operation.kwargs:
                 raise
 
@@ -1506,7 +1514,7 @@ class OpenGearFunction(GearFunction[optype.InputRecord]):
                 Defaults to ``None``.
 
             on (redis.Redis):
-                Immedeately execute the function on this Redis Gear server / cluster.
+                Immedeately execute the function on this RedisGears system.
 
             **kwargs:
                 Additional parameters to the run operation.
@@ -1580,7 +1588,7 @@ class OpenGearFunction(GearFunction[optype.InputRecord]):
                 Defaults to ``True``.
 
             collect (bool, optional):
-                When True adds a collect operation to flow's end.
+                When ``True`` adds a collect operation to flow's end.
                 Defaults to ``False``.
 
             mode (str, optional):
@@ -1693,7 +1701,7 @@ class OpenGearFunction(GearFunction[optype.InputRecord]):
                 Defaults to ``None``.
 
             on (redis.Redis):
-                Immedeately execute the function on this Redis Gear server / cluster.
+                Immedeately execute the function on this RedisGears system.
 
             **kwargs:
                 Additional parameters to the register operation.

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -89,8 +89,8 @@ class Operation:
         ``NotImplementedException`` if called directly on the `Operation` superclass.
 
         Args:
-            function (Union[Type, PartialGearFunction]):
-                The partial gear function to append this operation to.
+            function (Union[Type, OpenGearFunction]):
+                The "open" gear function to append this operation to.
 
                 If, and only if, the operation is a reader function (always and only
                 the first operation in any Gear function), then the `function`
@@ -113,19 +113,19 @@ class Nop(Operation):
     This Operation does nothing.
     """
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
         """Returns the function, unmodified.
 
         Args:
-            function (Union[Type, PartialGearFunction]):
-                The partial gear function to append this operation to.
+            function (Union[Type, OpenGearFunction]):
+                The "open" gear function to append this operation to.
 
                 If, and only if, the operation is a reader function (always and only
                 the first operation in any Gear function), then the `function`
                 argument must instead be a GearsBuilder class/type.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function unmodified.
         """
         return function
@@ -184,7 +184,7 @@ class Reader(Operation):
         self.defaultArg = defaultArg
         self.desc = desc
 
-    def add_to(self, builder: Type) -> "PartialGearFunction":
+    def add_to(self, builder: Type) -> "OpenGearFunction":
         """Create a new gear function based on this reader information.
 
         Args:
@@ -193,8 +193,8 @@ class Reader(Operation):
                 Gear function.
 
         Returns:
-            PartialGearFunction:
-                Returns a minimal partial gear function, consisting only of the
+            OpenGearFunction:
+                Returns a minimal "open" gear function, consisting only of the
                 reader.
         """
         return builder(self.reader, self.defaultArg, self.desc, **self.kwargs)
@@ -261,12 +261,12 @@ class Run(Operation):
         self.convertToStr = convertToStr
         self.collect = collect
 
-    def add_to(self, function: "PartialGearFunction") -> "ClosedGearFunction":
+    def add_to(self, function: "OpenGearFunction") -> "ClosedGearFunction":
         """Closes a Gear function with the Run action.
 
         Args:
-            function (PartialGearFunction):
-                The partial Gear function to close with the run action.
+            function (OpenGearFunction):
+                The "open" Gear function to close with the run action.
 
         Returns:
             ClosedGearFunction:
@@ -363,12 +363,12 @@ class Register(Operation):
         self.mode = mode
         self.onRegistered = onRegistered
 
-    def add_to(self, function: "PartialGearFunction") -> "ClosedGearFunction":
+    def add_to(self, function: "OpenGearFunction") -> "ClosedGearFunction":
         """Closes a Gear function with the Register action.
 
         Args:
-            function (PartialGearFunction):
-                The partial Gear function to close with the register action.
+            function (OpenGearFunction):
+                The "open" Gear function to close with the register action.
 
         Returns:
             ClosedGearFunction:
@@ -409,15 +409,15 @@ class Map(Operation):
         super().__init__(**kwargs)
         self.op = op
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.map(self.op, **self.kwargs)
@@ -450,15 +450,15 @@ class FlatMap(Operation):
         super().__init__(**kwargs)
         self.op = op
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.flatmap(self.op, **self.kwargs)
@@ -490,15 +490,15 @@ class ForEach(Operation):
         super().__init__(**kwargs)
         self.op = op
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.foreach(self.op, **self.kwargs)
@@ -532,15 +532,15 @@ class Filter(Operation):
         super().__init__(**kwargs)
         self.op = op
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.filter(self.op, **self.kwargs)
@@ -575,15 +575,15 @@ class Accumulate(Operation):
         super().__init__(**kwargs)
         self.op = op
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.accumulate(self.op, **self.kwargs)
@@ -628,15 +628,15 @@ class LocalGroupBy(Operation):
         self.extractor = extractor
         self.reducer = reducer
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.localgroupby(self.extractor, self.reducer, **self.kwargs)
@@ -671,15 +671,15 @@ class Limit(Operation):
         self.length = length
         self.start = start
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.limit(self.length, self.start, **self.kwargs)
@@ -694,15 +694,15 @@ class Collect(Operation):
         """Instantiate a Collect operation."""
         super().__init__(**kwargs)
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.collect(**self.kwargs)
@@ -738,15 +738,15 @@ class Repartition(Operation):
         super().__init__(**kwargs)
         self.extractor = extractor
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.repartition(self.extractor, **self.kwargs)
@@ -821,15 +821,15 @@ class Aggregate(Operation):
         self.seqOp = seqOp
         self.combOp = combOp
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.aggregate(self.zero, self.seqOp, self.combOp, **self.kwargs)
@@ -914,15 +914,15 @@ class AggregateBy(Operation):
         self.seqOp = seqOp
         self.combOp = combOp
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.aggregateby(
@@ -978,15 +978,15 @@ class GroupBy(Operation):
         self.extractor = extractor
         self.reducer = reducer
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.groupby(self.extractor, self.reducer, **self.kwargs)
@@ -1050,15 +1050,15 @@ class BatchGroupBy(Operation):
         self.extractor = extractor
         self.reducer = reducer
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.batchgroupby(self.extractor, self.reducer, **self.kwargs)
@@ -1097,15 +1097,15 @@ class Sort(Operation):
         super().__init__(**kwargs)
         self.reverse = reverse
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.sort(self.reverse, **self.kwargs)
@@ -1127,15 +1127,15 @@ class Distinct(Operation):
         """Instantiate a Distinct operation."""
         super().__init__(**kwargs)
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.distinct(**self.kwargs)
@@ -1154,15 +1154,15 @@ class Count(Operation):
         """Instantiate a Cound operation."""
         super().__init__(**kwargs)
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.count(**self.kwargs)
@@ -1194,15 +1194,15 @@ class CountBy(Operation):
         super().__init__(**kwargs)
         self.extractor = extractor
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.countby(self.extractor, **self.kwargs)
@@ -1237,15 +1237,15 @@ class Avg(Operation):
         super().__init__(**kwargs)
         self.extractor = extractor
 
-    def add_to(self, function: "PartialGearFunction") -> "PartialGearFunction":
-        """Adds the operation to a partial Gear function.
+    def add_to(self, function: "OpenGearFunction") -> "OpenGearFunction":
+        """Adds the operation to an "open" Gear function.
 
         Args:
-            function (PartialGearFunction):
-                The partial gear function to add the operation to.
+            function (OpenGearFunction):
+                The "open" gear function to add the operation to.
 
         Returns:
-            PartialGearFunction:
+            OpenGearFunction:
                 The function with the operation added to the end.
         """
         return function.avg(self.extractor, **self.kwargs)
@@ -1257,7 +1257,7 @@ class Avg(Operation):
 
 
 class GearFunction(Generic[T]):
-    """Abstract base class for both partial and closed Gear functions.
+    """Abstract base class for both "open" and closed Gear functions.
     The base `GearFunction` class is not intended to be instantiated by API users.
 
     A GearFunction is a chain of consecutive Operations.
@@ -1266,7 +1266,7 @@ class GearFunction(Generic[T]):
         operation (Operation):
             The last opertation in the functions chain of operations.
 
-        input_function (PartialGearFunction):
+        input_function (OpenGearFunction):
             The function (chain of operations) that provides the input records to the
             `operation`. Two different GearFunctions can share the same `input_function`
 
@@ -1278,7 +1278,7 @@ class GearFunction(Generic[T]):
     def __init__(
         self,
         operation: Operation,
-        input_function: "PartialGearFunction" = None,
+        input_function: "OpenGearFunction" = None,
         requirements: Optional[Iterable[str]] = None,
     ) -> None:
         """Instaniate a GearFunction
@@ -1287,7 +1287,7 @@ class GearFunction(Generic[T]):
             operation (Operation):
                 The last opertation in the functions chain of operations.
 
-            input_function (PartialGearFunction, optional):
+            input_function (OpenGearFunction, optional):
                 The function (chain of operations) that provides the input records to
                 the `operation`.
                 Defaults to ``None``.
@@ -1366,7 +1366,7 @@ class ClosedGearFunction(GearFunction[T]):
     def __init__(
         self,
         operation: Operation,
-        input_function: "PartialGearFunction" = None,
+        input_function: "OpenGearFunction" = None,
         requirements: Optional[Iterable[str]] = None,
     ) -> None:
         """"""
@@ -1441,11 +1441,11 @@ class ClosedGearFunction(GearFunction[T]):
             )
 
 
-class PartialGearFunction(GearFunction[optype.InputRecord]):
+class OpenGearFunction(GearFunction[optype.InputRecord]):
     """An open Gear function is a Gear function that is not yet "closed" with a
     :ref:`op_action_run` action or a :ref:`op_action_register` action.
 
-    Open Gear functions can be used to create new partial gear functions by
+    Open Gear functions can be used to create new "open" gear functions by
     applying :ref:`operations`, or it can create a closed Gear function by applying
     either the :ref:`op_action_run` action or a :ref:`op_action_register` action.
     """
@@ -1453,7 +1453,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
     def __init__(
         self,
         operation: Operation,
-        input_function: "PartialGearFunction" = None,
+        input_function: "OpenGearFunction" = None,
         requirements: Optional[Iterable[str]] = None,
     ) -> None:
         """"""
@@ -1772,7 +1772,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.OutputRecord]":
+    ) -> "OpenGearFunction[optype.OutputRecord]":
         """Instance-local :ref:`op_map` operation that performs a one-to-one (1:1) mapping of
         records.
 
@@ -1790,11 +1790,11 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_map` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_map` operation as last step.
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_map` operation as last step.
         """
         op = redgrease.utils.passfun(op)
-        return PartialGearFunction(
+        return OpenGearFunction(
             Map(op=op, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -1807,7 +1807,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Iterable[optype.OutputRecord]]":
+    ) -> "OpenGearFunction[Iterable[optype.OutputRecord]]":
         """Instance-local :ref:`op_flatmap` operation that performs one-to-many (1:N) mapping
         of records.
 
@@ -1827,12 +1827,12 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_flatmap` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_flatmap` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_flatmap` operation as last
                 step.
         """
         op = redgrease.utils.passfun(op)
-        return PartialGearFunction(
+        return OpenGearFunction(
             FlatMap(op=op, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -1845,7 +1845,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.InputRecord]":
+    ) -> "OpenGearFunction[optype.InputRecord]":
         """Instance-local :ref:`op_foreach` operation performs one-to-the-same (1=1) mapping.
 
         Args:
@@ -1862,12 +1862,12 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_foreach` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_foreach` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_foreach` operation as last
                 step.
         """
         op = redgrease.utils.passfun(op)
-        return PartialGearFunction(
+        return OpenGearFunction(
             ForEach(op=op, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -1880,7 +1880,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.InputRecord]":
+    ) -> "OpenGearFunction[optype.InputRecord]":
         """Instance-local :ref:`op_filter` operation performs one-to-zero-or-one (1:bool)
         filtering of records.
 
@@ -1901,12 +1901,12 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_filter` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_filter` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_filter` operation as last
                 step.
         """
         op = redgrease.utils.passfun(op)
-        return PartialGearFunction(
+        return OpenGearFunction(
             Filter(op=op, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -1919,7 +1919,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[T]":
+    ) -> "OpenGearFunction[T]":
         """Instance-local :ref:`op_accumulate` operation performs many-to-one mapping (N:1) of
         records.
 
@@ -1943,13 +1943,13 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_accumulate` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with :ref:`op_accumulate` operation as last
+            OpenGearFunction:
+                A new "open" gear function with :ref:`op_accumulate` operation as last
                 step.
         """
 
         op = redgrease.utils.passfun(op, default=_default_accumulator)
-        return PartialGearFunction(
+        return OpenGearFunction(
             Accumulate(op=op, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -1963,7 +1963,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Dict[optype.Key, T]]":
+    ) -> "OpenGearFunction[Dict[optype.Key, T]]":
         """Instance-local :ref:`op_localgroupby` operation performs many-to-less mapping (N:M)
         of records.
 
@@ -1993,13 +1993,13 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_localgroupby` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_localgroupby` operation as
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_localgroupby` operation as
                 last step.
         """
         extractor = redgrease.utils.passfun(extractor, default=_default_extractor)
         reducer = redgrease.utils.passfun(reducer, default=_default_reducer)
-        return PartialGearFunction(
+        return OpenGearFunction(
             LocalGroupBy(extractor=extractor, reducer=reducer, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2011,7 +2011,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         start: int = 0,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.InputRecord]":
+    ) -> "OpenGearFunction[optype.InputRecord]":
         """Instance-local :ref:`op_limit` operation limits the number of records.
 
         Args:
@@ -2030,16 +2030,16 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_limit`  operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_limit`  operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_limit`  operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Limit(length=length, start=start, **kwargs),
             input_function=self,
         )
 
-    def collect(self, **kwargs) -> "PartialGearFunction[optype.InputRecord]":
+    def collect(self, **kwargs) -> "OpenGearFunction[optype.InputRecord]":
         """Cluster-global :ref:`op_collect` operation collects the result records.
 
         Args:
@@ -2047,11 +2047,11 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_collect` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_collect` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_collect` operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Collect(**kwargs),
             input_function=self,
         )
@@ -2063,7 +2063,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.InputRecord]":
+    ) -> "OpenGearFunction[optype.InputRecord]":
         """Cluster-global :ref:`op_repartition` operation repartitions the records by
         shuffling
         them between shards.
@@ -2086,11 +2086,11 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_repartition` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_repartition` operation as
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_repartition` operation as
                 last step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Repartition(extractor=extractor, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2105,7 +2105,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[T]":
+    ) -> "OpenGearFunction[T]":
         """Distributed :ref:`op_aggregate` operation perform an aggregation on local
         data then a global aggregation on the local aggregations.
 
@@ -2145,8 +2145,8 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the ref:`op_aggregate` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a ref:`op_aggregate` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a ref:`op_aggregate` operation as last
                 step.
         """
 
@@ -2166,7 +2166,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         seqOp = redgrease.utils.passfun(seqOp)
         combOp = redgrease.utils.passfun(combOp, default=seqOp)
 
-        return PartialGearFunction(
+        return OpenGearFunction(
             Aggregate(zero=_zero, seqOp=seqOp, combOp=combOp, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2182,7 +2182,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Dict[optype.Key, T]]":
+    ) -> "OpenGearFunction[Dict[optype.Key, T]]":
         """Distributed :ref:`op_aggregateby` operation, behaves like aggregate, but
         separated on each key, extracted using the extractor.
 
@@ -2228,8 +2228,8 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_aggregateby` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_aggregateby` operation as
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_aggregateby` operation as
                 last step.
         """
 
@@ -2239,7 +2239,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         seqOp = redgrease.utils.passfun(seqOp, _default_reducer)
         combOp = redgrease.utils.passfun(combOp, seqOp)
 
-        return PartialGearFunction(
+        return OpenGearFunction(
             AggregateBy(
                 extractor=extractor, zero=_zero, seqOp=seqOp, combOp=combOp, **kwargs
             ),
@@ -2255,7 +2255,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Dict[optype.Key, T]]":
+    ) -> "OpenGearFunction[Dict[optype.Key, T]]":
         """Cluster-local :ref:`op_groupby` operation performing a many-to-less (N:M)
         grouping of records.
 
@@ -2284,14 +2284,14 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_groupby` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_groupby` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_groupby` operation as last
                 step.
         """
         extractor = redgrease.utils.passfun(extractor, default=_default_extractor)
         reducer = redgrease.utils.passfun(reducer, default=_default_reducer)
 
-        return PartialGearFunction(
+        return OpenGearFunction(
             GroupBy(extractor=extractor, reducer=reducer, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2305,7 +2305,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Dict[optype.Key, T]]":
+    ) -> "OpenGearFunction[Dict[optype.Key, T]]":
         """Cluster-local :ref:`op_groupby` operation, performing a many-to-less (N:M)
         grouping of records.
 
@@ -2333,13 +2333,13 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_groupby` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_groupby` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_groupby` operation as last
                 step.
         """
         extractor = redgrease.utils.passfun(extractor, default=_default_extractor)
         reducer = redgrease.utils.passfun(reducer, default=_default_batch_reducer)
-        return PartialGearFunction(
+        return OpenGearFunction(
             BatchGroupBy(extractor=extractor, reducer=reducer, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2352,7 +2352,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[optype.InputRecord]":
+    ) -> "OpenGearFunction[optype.InputRecord]":
         """:ref:`op_sort` the records
 
         Args:
@@ -2368,17 +2368,17 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_sort` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_sort` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_sort` operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Sort(reverse=reverse, **kwargs),
             input_function=self,
             requirements=requirements,
         )
 
-    def distinct(self, **kwargs) -> "PartialGearFunction[optype.InputRecord]":
+    def distinct(self, **kwargs) -> "OpenGearFunction[optype.InputRecord]":
         """Keep only the :ref:`op_distinct` values in the data.
 
         Args:
@@ -2386,16 +2386,16 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_distinct` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_distinct` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_distinct` operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Distinct(**kwargs),
             input_function=self,
         )
 
-    def count(self, **kwargs) -> "PartialGearFunction[int]":
+    def count(self, **kwargs) -> "OpenGearFunction[int]":
         """:ref:`op_count` the number of records in the execution.
 
         Args:
@@ -2403,11 +2403,11 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_count` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_count` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_count` operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Count(**kwargs),
             input_function=self,
         )
@@ -2419,7 +2419,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[Dict[Hashable, int]]":
+    ) -> "OpenGearFunction[Dict[Hashable, int]]":
         """Distributed :ref:`op_countby` operation countinig the records grouped by key.
 
         Args:
@@ -2438,12 +2438,12 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_countby` operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with a :ref:`op_countby` operation as last
+            OpenGearFunction:
+                A new "open" gear function with a :ref:`op_countby` operation as last
                 step.
         """
 
-        return PartialGearFunction(
+        return OpenGearFunction(
             CountBy(extractor=extractor, **kwargs),
             input_function=self,
             requirements=requirements,
@@ -2458,7 +2458,7 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> "PartialGearFunction[float]":
+    ) -> "OpenGearFunction[float]":
         """Distributed :ref:`op_avg` operation, calculating arithmetic average
         of the records.
 
@@ -2478,15 +2478,12 @@ class PartialGearFunction(GearFunction[optype.InputRecord]):
                 Additional parameters to the :ref:`op_avg`  operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with an :ref:`op_avg`  operation as last
+            OpenGearFunction:
+                A new "open" gear function with an :ref:`op_avg`  operation as last
                 step.
         """
-        return PartialGearFunction(
+        return OpenGearFunction(
             Avg(extractor=extractor, **kwargs),
             input_function=self,
             requirements=requirements,
         )
-
-
-OpenGearFunction = PartialGearFunction

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -35,7 +35,7 @@ import redgrease.typing
 import redgrease.utils
 
 
-class GearReader(redgrease.gears.PartialGearFunction[redgrease.typing.OutputRecord]):
+class GearReader(redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]):
     """Base class for the Reader sugar classes.
 
     Extends `redgrease.runtime.GearsBuilder' with arguments for collecting
@@ -91,7 +91,7 @@ class KeysReader(GearReader[redgrease.typing.Record]):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a KeysReader partial Gear function.
+        """Instantiate a KeysReader "open" Gear function.
 
         Args:
             default_key_pattern (str, optional):
@@ -114,7 +114,7 @@ class KeysReader(GearReader[redgrease.typing.Record]):
         )
         self.default_key_pattern = default_key_pattern
 
-    def values(self, type=..., event=...) -> redgrease.gears.PartialGearFunction:
+    def values(self, type=..., event=...) -> redgrease.gears.OpenGearFunction:
         """Filter out and select the values of the records only.
 
         Args:
@@ -131,15 +131,15 @@ class KeysReader(GearReader[redgrease.typing.Record]):
                 Defaults to ... (Ellipsis), menaing any event.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function generating the matching values.
+            OpenGearFunction:
+                A new "open" gear function generating the matching values.
         """
-        f: redgrease.gears.PartialGearFunction = self
+        f: redgrease.gears.OpenGearFunction = self
         if type != ... or event != ...:
             f = f.filter(redgrease.utils.dict_filter(type=type, event=event))
         return f.map(lambda record: record["value"])
 
-    def keys(self, type=..., event=...) -> redgrease.gears.PartialGearFunction[str]:
+    def keys(self, type=..., event=...) -> redgrease.gears.OpenGearFunction[str]:
         """Filter out and select the keys of the records only.
 
         Args:
@@ -156,17 +156,17 @@ class KeysReader(GearReader[redgrease.typing.Record]):
                 Defaults to ... (Ellipsis), menaing any event.
 
         Returns:
-            PartialGearFunction[str]:
-                A new partial gear function generating the matching keys.
+            OpenGearFunction[str]:
+                A new "open" gear function generating the matching keys.
         """
-        f: redgrease.gears.PartialGearFunction = self
+        f: redgrease.gears.OpenGearFunction = self
         if type != ... or event != ...:
             f = f.filter(redgrease.utils.dict_filter(type=type, event=event))
         return f.map(lambda record: record["key"])
 
     def records(
         self, type=..., event=...
-    ) -> redgrease.gears.PartialGearFunction[redgrease.utils.Record]:
+    ) -> redgrease.gears.OpenGearFunction[redgrease.utils.Record]:
         """Filter out and map the records to `redgrease.utils.Record` objects.
 
         This provides the fields `key`, `value`, `type` and `event` as typed attributes
@@ -187,10 +187,10 @@ class KeysReader(GearReader[redgrease.typing.Record]):
                 Defaults to ... (Ellipsis), menaing any event.
 
         Returns:
-            PartialGearFunction[redgrease.utils.Record]:
-                A new partial gear function generating the matching Record values.
+            OpenGearFunction[redgrease.utils.Record]:
+                A new "open" gear function generating the matching Record values.
         """
-        f: redgrease.gears.PartialGearFunction = self
+        f: redgrease.gears.OpenGearFunction = self
         if type != ... or event != ...:
             f = f.filter(redgrease.utils.dict_filter(type=type, event=event))
         return f.map(redgrease.utils.record)
@@ -205,7 +205,7 @@ class KeysOnlyReader(GearReader[str]):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a KeysOnlyReader partial Gear function.
+        """Instantiate a KeysOnlyReader "open" Gear function.
 
         Args:
             default_key_pattern (str, optional):
@@ -238,7 +238,7 @@ class StreamReader(GearReader[redgrease.typing.Record]):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a StreamReader partial Gear function.
+        """Instantiate a StreamReader "open" Gear function.
 
         Args:
             default_key_pattern (str, optional):
@@ -261,27 +261,27 @@ class StreamReader(GearReader[redgrease.typing.Record]):
         )
         self.default_key_pattern = default_key_pattern
 
-    def values(self) -> redgrease.gears.PartialGearFunction[Dict]:
+    def values(self) -> redgrease.gears.OpenGearFunction[Dict]:
         """Select the values of the stream only.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function generating values.
+            OpenGearFunction:
+                A new "open" gear function generating values.
         """
         return self.map(lambda record: record["value"])
 
-    def keys(self) -> redgrease.gears.PartialGearFunction[str]:
+    def keys(self) -> redgrease.gears.OpenGearFunction[str]:
         """Select the keys, i.e. stream names, only.
 
         Returns:
-            PartialGearFunction[str]:
-                A new partial gear function generating names.
+            OpenGearFunction[str]:
+                A new "open" gear function generating names.
         """
         return self.map(lambda record: record["key"])
 
     def records(
         self,
-    ) -> redgrease.gears.PartialGearFunction[redgrease.utils.StreamRecord]:
+    ) -> redgrease.gears.OpenGearFunction[redgrease.utils.StreamRecord]:
         """Filter out and map the records to `redgrease.utils.StreamRecord` objects.
 
         This provides the fields `key`, `id` and `value` as typed attributes on an
@@ -289,8 +289,8 @@ class StreamReader(GearReader[redgrease.typing.Record]):
         to work with.
 
         Returns:
-            PartialGearFunction[redgrease.utils.Record]:
-                A new partial gear function generating the matching Record values.
+            OpenGearFunction[redgrease.utils.Record]:
+                A new "open" gear function generating the matching Record values.
         """
         return self.map(redgrease.utils.stream_record)
 
@@ -303,7 +303,7 @@ class PythonReader(GearReader):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a PythonReader partial Gear function.
+        """Instantiate a PythonReader "open" Gear function.
 
         Args:
             desc (str, optional):
@@ -329,7 +329,7 @@ class ShardsIDReader(GearReader[str]):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a ShardsIDReader partial Gear function.
+        """Instantiate a ShardsIDReader "open" Gear function.
 
         Args:
             desc (str, optional):
@@ -355,7 +355,7 @@ class CommandReader(GearReader):
         desc: str = None,
         requirements: Optional[Iterable[str]] = None,
     ):
-        """Instantiate a CommandReader partial Gear function.
+        """Instantiate a CommandReader "open" Gear function.
 
         Args:
             desc (str, optional):
@@ -372,7 +372,7 @@ class CommandReader(GearReader):
             requirements=requirements,
         )
 
-    def args(self, max_count: int = None) -> redgrease.gears.PartialGearFunction:
+    def args(self, max_count: int = None) -> redgrease.gears.OpenGearFunction:
         """Ignore the trigger name and take only the arguments following the trigger.
 
         Args:
@@ -381,8 +381,8 @@ class CommandReader(GearReader):
                 Defaults to None.
 
         Returns:
-            redgrease.gears.PartialGearFunction:
-                A new partial gear function only generating the trigger arguments.
+            redgrease.gears.OpenGearFunction:
+                A new "open" gear function only generating the trigger arguments.
         """
         if max_count:
             max_count += 1
@@ -395,7 +395,7 @@ class CommandReader(GearReader):
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> redgrease.gears.PartialGearFunction[redgrease.typing.OutputRecord]:
+    ) -> redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]:
         """Apply a function to the trigger arguments.
 
         Args:
@@ -403,8 +403,8 @@ class CommandReader(GearReader):
                 The function to call with the trigger arguments.
 
         Returns:
-            redgrease.gears.PartialGearFunction[redgrease.typing.OutputRecord]:
-                A new partial gear function generating the results of the function.
+            redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]:
+                A new "open" gear function generating the results of the function.
         """
         return self.map(
             lambda args: fun(*args[1:]), requirements=requirements, **kwargs

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class GearsBuilder(redgrease.gears.PartialGearFunction):
+class GearsBuilder(redgrease.gears.OpenGearFunction):
     """The RedisGears :ref:`GearsBuilder` class is imported to the runtime's
     environment by default, and this class is a RedgGrease wrapper of it.
 
@@ -47,8 +47,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
 
         GearsBuilder is mutable with respect to the operations.
 
-        The :class:`.GearsBuilder` is a subclass of :class:`.gears.PartialGearFunction`,
-        but unlike other PartialGearFunctions, the GearsBuilder mutates an internal
+        The :class:`.GearsBuilder` is a subclass of :class:`.gears.OpenGearFunction`,
+        but unlike other OpenGearFunctions, the GearsBuilder mutates an internal
         GearFunction instead of creating a new one for each operation.
         This behaviour is deliberate, in order to be consistent with the original
         GearsBuilder.
@@ -92,8 +92,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
         """
         requirements = kwargs.pop("requirements", None)
         reader_op = redgrease.gears.Reader(reader, defaultArg, desc, *args, **kwargs)
-        self._function: redgrease.gears.PartialGearFunction = (
-            redgrease.gears.PartialGearFunction(
+        self._function: redgrease.gears.OpenGearFunction = (
+            redgrease.gears.OpenGearFunction(
                 operation=reader_op,
                 requirements=requirements,
             )
@@ -107,7 +107,7 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
         GearFunctions, independently from the GearsBuilder.
 
         Returns:
-            redgrease.gears.PartialGearFunction:
+            redgrease.gears.OpenGearFunction:
                 The current GearFunction object.
         """
         return self._function
@@ -865,8 +865,8 @@ class GearsBuilder(redgrease.gears.PartialGearFunction):
                 Additional parameters to the map operation.
 
         Returns:
-            PartialGearFunction:
-                A new partial gear function with an avg operation as last step.
+            OpenGearFunction:
+                A new "open" gear function with an avg operation as last step.
                 GearsBuilder - The same GearBuilder, but with updated function.
 
                 Note that for GearBuilder this method does **not** return a new


### PR DESCRIPTION
# Pull Request Overview:
Changed PartialGearFunction to OpenGearFunction, an changed docs wording accordingly.

# Main Changes:
All (hopefully) references to "partial" gear functions, both in code and documentation, now refer to "open" instead. 

# Additional Info
Partial Gear functions was not a great naming, as partial functions is a very specific and completely different thing in mathematics.


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
