### PR TITLE
Docs

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -5,7 +5,7 @@
 Advanced Concepts
 =================
 
-.. include :: wip.rst
+This section discuss some more advanced topics, considerations an usage patterns.
 
 .. _adv_extras:
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -34,6 +34,9 @@ For the server you may want to consider these different options:
 
     To enforce this option, ensure that any calls to :meth:`.Gears.pyexecute` explicitly set the ``enforce_redgrease`` argument to ``"redgrease"`` (without extras). Version qualifiers are supported (e.g. ``"redgrease>0.3"``).
 
+
+.. _adv_no_redgrease:
+
 - Nothing
 
    Yes, In some cases RedGrease may be of value even if it is **not** installed in the RedisGears runtime environment. If your are only executing GearFunctions by :ref:`exe_gear_function_file`, and the script itself is either:
@@ -136,10 +139,28 @@ The "clean" RedGrease modules, that can be used without extra dependencies are:
 Python 3.6 and 3.8+ 
 -------------------
 
-.. _adv_pure:
+Dynamically created :ref:`gearfun` objects can only be exectuted if the client Python version match (major and minor version) the Python version of the RedisGaers runtime. At the moment of writing, RedisGears version 1.0.6, is relying on Python 3.7. 
 
-Pure Gear Scripts
------------------
+RedGrease does however support using any Python version after Python 3.6 inclusive, for all other functionalities. 
+
+You are still able to constuct an run Gear functions using the RedGrease :ref:`gearfun` objects, but only if executed using :ref:`exe_gear_function_file`.
+
+This means that you need to:
+
+#. Put your Gear Function code in a separate file from your application code.
+#. Ensure that the Gear Function script, only use Python 3.7 constucts.
+#. Excute the function by passing the script file path to :meth:`redgrease.client.Gears.pyexecute`.
+
+.. _adv_legacay:
+
+Legacy Gear Scripts
+-------------------
+
+You do not have to change any of your existing legacy scripts to start using RedGrease.
+
+RedGrease support running "vanilla" RedisGears Gear functions, i.e. without any RedGrease features, by execution using :ref:`exe_gear_function_file`.
+
+If you however need to modify any of your legacy scripts, it may be a good idea to add ``from redgrease import execute, atomic, configGet, gearsConfigGet, hashtag, log, GearsBuilder, GB`` to the import section of your script so that you get the benefits of autocompletion and write-time type checking (assuming your IDE supports it).
 
 
 .. include :: footer.rst

--- a/docs/source/cache_get_faulty.rst
+++ b/docs/source/cache_get_faulty.rst
@@ -1,7 +1,7 @@
 .. _quick_example_command:
 
 Cache Get Command
----------------
+-----------------
 
 As a final example of this quickstart tutorial, let's look at how we can build caching into Redis as a new command, with the help of Redis Gears and RedGrease.
 
@@ -182,7 +182,11 @@ And you should indeed see that the expected log messages appear:
 
 The last piece of code is jut to clean up the database by unregistering the ``cache_get`` Gear function, cancel and drom any ongoing Gear function executions and flush the key-space.
 
-.. literalinclude:: ../../examples/cache_get_command_faulty_faulty.py
+.. literalinclude:: ../../examples/cache_get_command_faulty.py
     :start-after: Clean the database
     :caption: Clean up the database: 
     :lineno-match:
+
+.. |br| raw:: html
+
+    <br />

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,22 @@ version = str(current_version)
 
 # -- General configuration ---------------------------------------------------
 autoclass_content = "both"
+autodoc_member_order = "bysource"
+
+autodoc_type_aliases = {
+    "Accumulator": "redgrease.typing.Accumulator",
+    "BatchReducer": "redgrease.typing.BatchReducer",
+    "Callback": "redgrease.typing.Callback",
+    "Expander": "redgrease.typing.Expander",
+    "Extractor": "redgrease.typing.Extractor",
+    "Filterer": "redgrease.typing.Filterer",
+    "InputRecord": "redgrease.typing.InputRecord",
+    "Key": "redgrease.typing.Key",
+    "Mapper": "redgrease.typing.Mapper",
+    "OutputRecord": "redgrease.typing.OutputRecord",
+    "Processor": "redgrease.typing.Processor",
+    "Reducer": "redgrease.typing.Reducer",
+}
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -44,9 +60,10 @@ autoclass_content = "both"
 extensions: List[str] = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    # "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
     "sphinx_tabs.tabs",
-    #    "sphinxcontrib.osexample",
+    # "sphinxcontrib.osexample",
 ]
 # ["recommonmark"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ autodoc_member_order = "bysource"
 autodoc_type_aliases = {
     "Accumulator": "redgrease.typing.Accumulator",
     "BatchReducer": "redgrease.typing.BatchReducer",
-    "Callback": "redgrease.typing.Callback",
+    "Registrator": "redgrease.typing.Registrator",
     "Expander": "redgrease.typing.Expander",
     "Extractor": "redgrease.typing.Extractor",
     "Filterer": "redgrease.typing.Filterer",

--- a/docs/source/gearfunctions.rst
+++ b/docs/source/gearfunctions.rst
@@ -67,7 +67,6 @@ This includes both the :class:`.runtime.GearsBuilder` as well as the :ref:`gearf
 
 .. autoclass:: redgrease.gears.OpenGearFunction()
     :members:
-    :member-order: bysource
 
 
 .. _gearfun_closed:
@@ -78,7 +77,6 @@ ClosedGearFunction
 .. autoclass:: redgrease.gears.ClosedGearFunction()
     :members:
     :undoc-members:
-    :member-order: bysource
 
 
 .. _gearfun_builder:
@@ -107,7 +105,7 @@ KeysReader
 .. autoclass:: redgrease.reader.KeysReader
     :members:
     :undoc-members:
-    :member-order: bysource
+
 
 
 .. _gearfun_reader_keysonlyreader:
@@ -118,7 +116,6 @@ KeysOnlyReader
 .. autoclass:: redgrease.reader.KeysOnlyReader
     :members:
     :undoc-members:
-    :member-order: bysource
 
 
 
@@ -130,7 +127,6 @@ StreamReader
 .. autoclass:: redgrease.reader.StreamReader
     :members:
     :undoc-members:
-    :member-order: bysource
 
 
 
@@ -142,7 +138,6 @@ PythonReader
 .. autoclass:: redgrease.reader.PythonReader
     :members:
     :undoc-members:
-    :member-order: bysource
 
 
 
@@ -154,7 +149,6 @@ ShardsIDReader
 .. autoclass:: redgrease.reader.ShardsIDReader
     :members:
     :undoc-members:
-    :member-order: bysource
 
 
 
@@ -166,8 +160,8 @@ CommandReader
 .. autoclass:: redgrease.reader.CommandReader
     :members:
     :undoc-members:
-    :member-order: bysource
 
+    
 
 .. include :: footer.rst
 

--- a/docs/source/operations.rst
+++ b/docs/source/operations.rst
@@ -5,62 +5,106 @@
 Operations
 ==========
 
-.. include :: wip.rst
+This section goes through the various opertions available to :ref:`gearfun_open` in more detail.
 
 .. _op_map:
 
 Map 
 ---
 
+.. autoclass:: redgrease.gears.Map
+
+
+
 .. _op_flatmap:
 
 FlatMap
 -------
 
+.. autoclass:: redgrease.gears.FlatMap
+
+
+
 .. _op_foreach:
 
-ForEach 
+ForEach
 -------
+
+.. autoclass:: redgrease.gears.ForEach
+
+
 
 .. _op_filter:
 
 Filter
 ------
 
+.. autoclass:: redgrease.gears.Filter
+
+
+
 .. _op_accumulate:
 
 Accumulate
 ----------
+
+.. autoclass:: redgrease.gears.Accumulate
+
+
 
 .. _op_localgroupby:
 
 LocalGroupBy
 ------------
 
+.. autoclass:: redgrease.gears.LocalGroupBy
+
+
+
 .. _op_limit:
 
 Limit
 -----
+
+.. autoclass:: redgrease.gears.Limit
+
+
 
 .. _op_collect:
 
 Collect
 -------
 
+.. autoclass:: redgrease.gears.Collect
+
+
+
 .. _op_repartition:
 
 Repartition
 -----------
+
+.. autoclass:: redgrease.gears.Repartition
+
+
 
 .. _op_aggregate:
 
 Aggregate
 ---------
 
+.. autoclass:: redgrease.gears.Aggregate
+
+
+
 .. _op_aggregateby:
 
 AggregateBy
 -----------
+
+.. autoclass:: redgrease.gears.AggregateBy
+
+
 
 .. _op_groupby:
 
@@ -72,47 +116,144 @@ GroupBy
 BatchGroupBy
 ------------
 
+.. autoclass:: redgrease.gears.BatchGroupBy
+
+
+
 .. _op_sort:
 
 Sort
 ----
+
+.. autoclass:: redgrease.gears.Sort
+
+
 
 .. _op_distinct:
 
 Distinct
 --------
 
+.. autoclass:: redgrease.gears.Distinct
+
+
+
 .. _op_count:
 
 Count
 -----
+
+.. autoclass:: redgrease.gears.Count
+
+
 
 .. _op_countby:
 
 CountBy
 -------
 
+.. autoclass:: redgrease.gears.CountBy
+
+
+
 .. _op_avg:
 
 Avg
 ---
+
+.. autoclass:: redgrease.gears.Avg
+
+
 
 .. _op_action:
 
 Actions
 =======
 
+Actions closes open GearFunctions, and indicates the running mode of the function, as follows:
+
+==========================  ==============
+Action                      Execution Mode
+==========================  ==============
+:ref:`op_action_run`        "batch-mode"
+:ref:`op_action_register`   "event-mode"
+==========================  ==============
+
 .. _op_action_run:
 
 Run 
 ---
+
+.. autoclass:: redgrease.gears.Run
+
+
 
 .. _op_action_register:
 
 Register
 --------
 
+.. autoclass:: redgrease.gears.Register
 
+
+
+Operation Callback Types
+========================
+
+This section runs through the various type signatures that the function callbacks used in the :ref:`operations` must follow.
+
+Callback
+--------
+
+.. autodata:: redgrease.typing.Callback
+
+
+Extractor
+---------
+
+.. autodata:: redgrease.typing.Extractor
+
+
+Mapper
+------
+
+.. autodata:: redgrease.typing.Mapper
+
+
+Expander
+--------
+
+.. autodata:: redgrease.typing.Expander
+
+
+Processor
+---------
+
+.. autodata:: redgrease.typing.Processor
+
+
+Filterer
+--------
+
+.. autodata:: redgrease.typing.Filterer
+
+
+Accumulator
+-----------
+
+.. autodata:: redgrease.typing.Accumulator
+
+
+Reducer
+-------
+
+.. autodata:: redgrease.typing.Reducer
+
+
+BatchReducer
+------------
+
+.. autodata:: redgrease.typing.BatchReducer
 
 
 .. include :: footer.rst

--- a/docs/source/operations.rst
+++ b/docs/source/operations.rst
@@ -202,10 +202,11 @@ Operation Callback Types
 
 This section runs through the various type signatures that the function callbacks used in the :ref:`operations` must follow.
 
-Callback
---------
+Registrator
+-----------
 
-.. autodata:: redgrease.typing.Callback
+.. autodata:: redgrease.typing.Registrator
+
 
 
 Extractor

--- a/docs/source/redgrease.rst
+++ b/docs/source/redgrease.rst
@@ -29,13 +29,13 @@ redgrease.utils module
    :show-inheritance:
 
 
-redgrease.typing module
------------------------
+.. redgrease.typing module
+.. -----------------------
 
-.. automodule:: redgrease.typing
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. .. automodule:: redgrease.typing
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:
 
 
 .. Modules

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,6 +1,8 @@
 # Requirements for building the Documentation
-readthedocs-sphinx-search==0.1.0
-sphinx==3.5.3
-sphinx-rtd-theme==0.5.1
-Pygments==2.8.1
-sphinx-tabs==2.1.0
+readthedocs-sphinx-search  # ==0.1.0
+sphinx  # ==4.0.0b1  # 3.5.3
+sphinx-rtd-theme  # ==0.5.1
+Pygments  # ==2.8.1
+sphinx-tabs  # ==2.1.0
+sphinx-autodoc-napoleon-typehints  # ==2.1.6
+# sphinx-autodoc-typehints==1.12.0

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -289,7 +289,6 @@ The :class:`.runtime.GearsBuilder` (as well as its short-form alias ``GB``), beh
    :members:
    :undoc-members:
    :inherited-members:
-   :member-order: bysource
 
 
 

--- a/docs/source/serverside_commands.rst
+++ b/docs/source/serverside_commands.rst
@@ -5,6 +5,28 @@
 Serverside Redis Commands
 =========================
 
-.. include :: wip.rst
+With the RedGrease :ref:`runtime package installed on the RedGrease server <adv_extras>`, you can execute Redis commands to the local shards using "serverside commands" instead of using :func:`redgrease.runtime.execute` inside your Gear functions.
+
+Serverside Redis Commands, behaves almost identical to a normal Redis client, except that you do not have to instantiate it.
+
+Inside any Gear function, you can simply invoke Redis commands just as you would in your client using ``redgrease.cmd``:
+
+Example::
+
+    redgrease.cmd.set("Foo", "Bar")
+
+
+.. warning::
+
+    Serverside Redis Commands have the following limitations:
+
+    A. Only executes commands against the local shard. 
+        This is also the caser for both the :func:`redgrease.runtime.execute` function as well as the the RedisGears default builtin `execute()` function too.
+
+    B. Blocking commands, such as "BRPOP" or "BLPOP" ect, are not supported. 
+        This is also the caser for both the :func:`redgrease.runtime.execute` function as well as the the RedisGears default builtin `execute()` function too.
+
+
+
 
 .. include :: footer.rst

--- a/src/redgrease/client.py
+++ b/src/redgrease/client.py
@@ -49,7 +49,8 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 import ast
 import fnmatch
 import logging
-import warnings
+
+# import warnings
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union
 
 import redis
@@ -927,10 +928,10 @@ def RedisGears(*args, **kwargs):
     """Deprecated
     Use RedisMods instead
     """
-    warnings.warn(
-        """Instantiation using `RedisGears` will be deprecated.
-        Please use `RedisMods` instead.""",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    # warnings.warn(
+    #     """Instantiation using `RedisGears` will be deprecated.
+    #     Please use `RedisMods` instead.""",
+    #     DeprecationWarning,
+    #     stacklevel=2,
+    # )
     return RedisMods(*args, **kwargs)

--- a/src/redgrease/func.py
+++ b/src/redgrease/func.py
@@ -31,7 +31,7 @@ from typing import Callable
 import redgrease.reader
 import redgrease.sugar
 from redgrease.gears import ClosedGearFunction
-from redgrease.typing import Callback
+from redgrease.typing import Registrator
 
 
 def command(
@@ -39,7 +39,7 @@ def command(
     prefix: str = "*",
     collect: bool = True,
     mode: str = redgrease.sugar.TriggerMode.Async,
-    onRegistered: Callback = None,
+    onRegistered: Registrator = None,
     **kargs,
 ) -> Callable[[Callable], ClosedGearFunction]:
     """Decorator for creation of CommandReader + Tigger GearFunctions
@@ -66,7 +66,7 @@ def command(
             Same as for the `register` operation.
             Defaults to redgrease.sugar.TriggerMode.Async.
 
-        onRegistered (:data:`redgrease.typing.Callback`, optional):
+        onRegistered (:data:`redgrease.typing.Registrator`, optional):
             A function callback thats called on each shard upon function registration.
             It is a good place to initialize non-serializable objects such as
             network connections.

--- a/src/redgrease/func.py
+++ b/src/redgrease/func.py
@@ -66,7 +66,7 @@ def command(
             Same as for the `register` operation.
             Defaults to redgrease.sugar.TriggerMode.Async.
 
-        onRegistered (Callback, optional):
+        onRegistered (:data:`redgrease.typing.Callback`, optional):
             A function callback thats called on each shard upon function registration.
             It is a good place to initialize non-serializable objects such as
             network connections.

--- a/src/redgrease/gears.py
+++ b/src/redgrease/gears.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import annotations
+# from __future__ import annotations
 
 """
 GearsFunction and Operation definintions
@@ -36,7 +36,6 @@ import redgrease.utils
 from redgrease.typing import (
     Accumulator,
     BatchReducer,
-    Callback,
     Expander,
     Extractor,
     Filterer,
@@ -46,6 +45,7 @@ from redgrease.typing import (
     OutputRecord,
     Processor,
     Reducer,
+    Registrator,
 )
 
 T = TypeVar("T")
@@ -331,7 +331,7 @@ class Register(Operation):
         convertToStr: bool = True,
         collect: bool = True,
         mode: str = sugar.TriggerMode.Async,
-        onRegistered: Callback = None,
+        onRegistered: Registrator = None,
         **kwargs,
     ) -> None:
         """Instantiate a Register action
@@ -369,7 +369,7 @@ class Register(Operation):
 
                 Defaults to `redgrease.TriggerMode.Async` (``"async"``)
 
-            onRegistered (Callback, optional):
+            onRegistered (Registrator, optional):
                 A function callback that's called on each shard upon function
                 registration.
                 It is a good place to initialize non-serializable objects such as
@@ -1581,7 +1581,7 @@ class OpenGearFunction(GearFunction[InputRecord]):
         collect: bool = True,
         # Helpers, all must be None
         mode: str = None,
-        onRegistered: Callback = None,
+        onRegistered: Registrator = None,
         eventTypes: Iterable[str] = None,
         keyTypes: Iterable[str] = None,
         readValue: bool = None,
@@ -1638,7 +1638,7 @@ class OpenGearFunction(GearFunction[InputRecord]):
 
                 Defaults to ``"async"``.
 
-            onRegistered (Callback, optional):
+            onRegistered (Registrator, optional):
                 A function that's called on each shard upon function registration.
                 It is a good place to initialize non-serializable objects such as
                 network connections.

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import annotations
+# from __future__ import annotations
 
 """
 Sugar classes for the various Gears Reader types.

--- a/src/redgrease/reader.py
+++ b/src/redgrease/reader.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 """
 Sugar classes for the various Gears Reader types.
 """
@@ -31,11 +33,11 @@ from typing import Callable, Dict, Iterable, Optional
 
 import redgrease.gears
 import redgrease.sugar
-import redgrease.typing
 import redgrease.utils
+from redgrease.typing import OutputRecord, Record
 
 
-class GearReader(redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]):
+class GearReader(redgrease.gears.OpenGearFunction[OutputRecord]):
     """Base class for the Reader sugar classes.
 
     Extends `redgrease.runtime.GearsBuilder' with arguments for collecting
@@ -82,7 +84,7 @@ class GearReader(redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]
         super().__init__(operation=reader_op, requirements=requirements)
 
 
-class KeysReader(GearReader[redgrease.typing.Record]):
+class KeysReader(GearReader[Record]):
     """KeysReader is a convenience class for GearsBuilder("KeysReader", ...)"""
 
     def __init__(
@@ -229,7 +231,7 @@ class KeysOnlyReader(GearReader[str]):
         self.default_key_pattern = default_key_pattern
 
 
-class StreamReader(GearReader[redgrease.typing.Record]):
+class StreamReader(GearReader[Record]):
     """StreamReader is a convenience class for GearsBuilder("StreamReader", ...)"""
 
     def __init__(
@@ -390,20 +392,20 @@ class CommandReader(GearReader):
 
     def apply(
         self,
-        fun: Callable[..., redgrease.typing.OutputRecord],
+        fun: Callable[..., OutputRecord],
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
         **kwargs,
-    ) -> redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]:
+    ) -> redgrease.gears.OpenGearFunction[OutputRecord]:
         """Apply a function to the trigger arguments.
 
         Args:
-            fun (Callable[..., redgrease.typing.OutputRecord]):
+            fun (Callable[..., :data:`redgrease.typing.OutputRecord`]):
                 The function to call with the trigger arguments.
 
         Returns:
-            redgrease.gears.OpenGearFunction[redgrease.typing.OutputRecord]:
+            redgrease.gears.OpenGearFunction[:data:`redgrease.typing.OutputRecord`]:
                 A new "open" gear function generating the results of the function.
         """
         return self.map(

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 """
 Redgrease's (overloaded) variants of the symbols loaded per default into the top level
 namespace of Gear functions in the Redis server Python runtime.
@@ -31,7 +33,20 @@ from typing import TYPE_CHECKING, Hashable, Iterable, TypeVar
 import redgrease.gears
 
 if TYPE_CHECKING:
-    import redgrease.typing as optype
+    from redgrease.typing import (
+        Accumulator,
+        BatchReducer,
+        Callback,
+        Expander,
+        Extractor,
+        Filterer,
+        InputRecord,
+        Key,
+        Mapper,
+        OutputRecord,
+        Processor,
+        Reducer,
+    )
 
 T = TypeVar("T")
 
@@ -141,7 +156,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         collect: bool = True,
         # Helpers, all must be None
         mode: str = None,
-        onRegistered: "optype.Callback" = None,
+        onRegistered: Callback = None,
         eventTypes: Iterable[str] = None,
         keyTypes: Iterable[str] = None,
         readValue: bool = None,
@@ -183,7 +198,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def map(
         self,
-        op: "optype.Mapper[optype.InputRecord, optype.OutputRecord]",
+        op: Mapper[InputRecord, OutputRecord],
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -193,7 +208,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         records.
 
         Args:
-            op (redgrease.typing.Mapper):
+            op :data:`redgrease.typing.Mapper`):
                 Function to map on the input records.
                 The function must take one argument as input (input record) and
                 return something as an output (output record).
@@ -216,7 +231,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def flatmap(
         self,
-        op: "optype.Expander[optype.InputRecord, optype.OutputRecord]" = None,
+        op: Expander[InputRecord, OutputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -226,7 +241,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         of records.
 
         Args:
-            op (redgrease.typing.Expander, optional):
+            op :data:`redgrease.typing.Expander`, optional):
                 Function to map on the input records.
                 The function must take one argument as input (input record) and
                 return an iterable as an output (output records).
@@ -253,7 +268,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def foreach(
         self,
-        op: "optype.Processor[optype.InputRecord]",
+        op: Processor[InputRecord],
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -262,7 +277,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         """Instance-local :ref:`op_foreach` operation performs one-to-the-same (1=1) mapping.
 
         Args:
-            op (redgrease.typing.Processor):
+            op :data:`redgrease.typing.Processor`):
                 Function to run on each of the input records.
                 The function must take one argument as input (input record) and
                 should not return anything.
@@ -287,7 +302,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def filter(
         self,
-        op: "optype.Filterer[optype.InputRecord]" = None,
+        op: Filterer[InputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -297,7 +312,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         filtering of records.
 
         Args:
-            op (redgrease.typing.Filterer, optional):
+            op :data:`redgrease.typing.Filterer`, optional):
                 Function to apply on the input records, to decide which ones to keep.
                 The function must take one argument as input (input record) and
                 return a bool. The input records evaluated to `True` will be kept as
@@ -325,7 +340,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def accumulate(
         self,
-        op: "optype.Accumulator[T, optype.InputRecord]" = None,
+        op: Accumulator[T, InputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -335,7 +350,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         records.
 
         Args:
-            op (redgrease.typing.Accumulator, optional):
+            op :data:`redgrease.typing.Accumulator`, optional):
                 Function to to apply on the input records.
                 The function must take two arguments as input:
                     - An accumulator value, and
@@ -366,8 +381,8 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def localgroupby(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, optype.Key]" = None,
-        reducer: "optype.Reducer[optype.Key, T, optype.InputRecord]" = None,
+        extractor: Extractor[InputRecord, Key] = None,
+        reducer: Reducer[Key, T, InputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -377,14 +392,14 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         of records.
 
         Args:
-            extractor (redgrease.typing.Extractor, optional):
+            extractor :data:`redgrease.typing.Extractor`, optional):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).
                 The groups are defined by the value of the key.
                 Defaults to the hash of the input.
 
-            reducer (redgrease.typing.Reducer, optional):
+            reducer :data:`redgrease.typing.Reducer`, optional):
                 Function to apply on the records of each group, to reduce to a single
                 value (per group).
                 The function must take (a) a key, (b) an input record and (c) a
@@ -468,7 +483,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def repartition(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, Hashable]",
+        extractor: Extractor[InputRecord, Hashable],
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -478,7 +493,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         them between shards.
 
         Args:
-            extractor (redgrease.typing.Extractor):
+            extractor :data:`redgrease.typing.Extractor`):
                 Function that takes a record and calculates a key that is used to
                 determine the hash slot, and consequently the shard, that the record
                 should migrate to to.
@@ -508,8 +523,8 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
     def aggregate(
         self,
         zero: T = None,
-        seqOp: "optype.Accumulator[T, optype.InputRecord]" = None,
-        combOp: "optype.Accumulator[T, T]" = None,
+        seqOp: Accumulator[T, InputRecord] = None,
+        combOp: Accumulator[T, T] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -523,7 +538,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
                 The initial / zero value of the accumulator variable.
                 Defaults to an empty list.
 
-            seqOp (redgrease.typing.Accumulator, optional):
+            seqOp :data:`redgrease.typing.Accumulator`, optional):
                 A function to be applied on each of the input records, locally per
                 shard.
                 It must take two parameters:
@@ -535,7 +550,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
                 Defaults to addition, if 'zero' is a number and to a list accumulator
                 if 'zero' is a list.
 
-            combOp (redgrease.typing.Accumulator, optional):
+            combOp :data:`redgrease.typing.Accumulator`, optional):
                 A function to be applied on each of the aggregated results of the local
                 aggregation (i.e. the output of `seqOp`).
                 It must take two parameters:
@@ -570,10 +585,10 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def aggregateby(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, optype.Key]" = None,
+        extractor: Extractor[InputRecord, Key] = None,
         zero: T = None,
-        seqOp: "optype.Reducer[optype.Key, T, optype.InputRecord]" = None,
-        combOp: "optype.Reducer[optype.Key, T, T]" = None,
+        seqOp: Reducer[Key, T, InputRecord] = None,
+        combOp: Reducer[Key, T, T] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -583,7 +598,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         separated on each key, extracted using the extractor.
 
         Args:
-            extractor (redgrease.typing.Extractor, optional):
+            extractor :data:`redgrease.typing.Extractor`, optional):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).
@@ -594,7 +609,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
                 The initial / zero value of the accumulator variable.
                 Defaults to an empty list.
 
-            seqOp (redgrease.typing.Accumulator, optional):
+            seqOp :data:`redgrease.typing.Accumulator`, optional):
                 A function to be applied on each of the input records, locally per
                 shard and group.
                 It must take two parameters:
@@ -605,7 +620,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
                 The function must return the accumulator's updated value.
                 Defaults to a list reducer.
 
-            combOp (redgrease.typing.Accumulator):
+            combOp :data:`redgrease.typing.Accumulator`):
                 A function to be applied on each of the aggregated results of the local
                 aggregation (i.e. the output of `seqOp`).
                 It must take two parameters:
@@ -641,8 +656,8 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def groupby(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, optype.Key]" = None,
-        reducer: "optype.Reducer[optype.Key, T, optype.InputRecord]" = None,
+        extractor: Extractor[InputRecord, Key] = None,
+        reducer: Reducer[Key, T, InputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -652,14 +667,14 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         grouping of records.
 
         Args:
-            extractor (redgrease.typing.Extractor, optional):
+            extractor :data:`redgrease.typing.Extractor`, optional):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).
                 The groups are defined by the value of the key.
                 Defaults to the hash of the input.
 
-            reducer (redgrease.typing.Reducer, optional):
+            reducer :data:`redgrease.typing.Reducer`, optional):
                 Function to apply on the records of each group, to reduce to a single
                 value (per group).
                 The function must take (a) a key, (b) an input record and (c) a
@@ -688,8 +703,8 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def batchgroupby(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, optype.Key]" = None,
-        reducer: "optype.BatchReducer[optype.Key, T, optype.InputRecord]" = None,
+        extractor: Extractor[InputRecord, Key] = None,
+        reducer: BatchReducer[Key, T, InputRecord] = None,
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -702,14 +717,14 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
                 during runtime. Consider using the GroupBy
 
         Args:
-            extractor (redgrease.typing.Extractor, optional):
+            extractor :data:`redgrease.typing.Extractor`, optional):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).
                 The groups are defined by the value of the key.
                 Defaults to the hash of the input.
 
-            reducer (redgrease.typing.Reducer):
+            reducer :data:`redgrease.typing.Reducer`):
                 Function to apply on the records of each group, to reduce to a single
                 value (per group).
                 The function must take (a) a key, (b) an input record and (c) a
@@ -799,7 +814,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def countby(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, Hashable]" = lambda x: str(x),
+        extractor: Extractor[InputRecord, Hashable] = lambda x: str(x),
         # Other Redgrease args
         requirements: Iterable[str] = None,
         # Other Redis Gears args
@@ -808,7 +823,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         """Distributed :ref:`op_countby` operation countinig the records grouped by key.
 
         Args:
-            extractor (redgrease.typing.Extractor):
+            extractor :data:`redgrease.typing.Extractor`):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).
@@ -839,7 +854,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
 
     def avg(
         self,
-        extractor: "optype.Extractor[optype.InputRecord, float]" = lambda x: float(
+        extractor: Extractor[InputRecord, float] = lambda x: float(
             x if isinstance(x, (int, float, str)) else str(x)
         ),
         # Other Redgrease args
@@ -850,7 +865,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         """Distributed :ref:`op_avg` operation, calculating arithmetic average of the records.
 
         Args:
-            extractor (redgrease.typing.Extractor):
+            extractor :data:`redgrease.typing.Extractor`):
                 Function to apply on the input records, to extact the grouping key.
                 The function must take one argument as input (input record) and
                 return a string (key).

--- a/src/redgrease/runtime.py
+++ b/src/redgrease/runtime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import annotations
+# from __future__ import annotations
 
 """
 Redgrease's (overloaded) variants of the symbols loaded per default into the top level
@@ -28,25 +28,25 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import TYPE_CHECKING, Hashable, Iterable, TypeVar
+from typing import Hashable, Iterable, TypeVar
 
 import redgrease.gears
 
-if TYPE_CHECKING:
-    from redgrease.typing import (
-        Accumulator,
-        BatchReducer,
-        Callback,
-        Expander,
-        Extractor,
-        Filterer,
-        InputRecord,
-        Key,
-        Mapper,
-        OutputRecord,
-        Processor,
-        Reducer,
-    )
+# if TYPE_CHECKING:
+from redgrease.typing import (
+    Accumulator,
+    BatchReducer,
+    Expander,
+    Extractor,
+    Filterer,
+    InputRecord,
+    Key,
+    Mapper,
+    OutputRecord,
+    Processor,
+    Reducer,
+    Registrator,
+)
 
 T = TypeVar("T")
 
@@ -156,7 +156,7 @@ class GearsBuilder(redgrease.gears.OpenGearFunction):
         collect: bool = True,
         # Helpers, all must be None
         mode: str = None,
-        onRegistered: Callback = None,
+        onRegistered: Registrator = None,
         eventTypes: Iterable[str] = None,
         keyTypes: Iterable[str] = None,
         readValue: bool = None,

--- a/src/redgrease/typing.py
+++ b/src/redgrease/typing.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# from __future__ import annotations
+
 """
 Type variables, Type aliases and Protocol Types.
 """
@@ -27,25 +29,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 """
 
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
-
-if TYPE_CHECKING:
-    try:
-        from typing import Protocol
-    except ImportError:
-        from typing_extensions import Protocol  # type: ignore
-else:
-    Protocol = Tuple  # Hack 2000
+from typing import Any, Callable, Dict, Iterable, Type, TypeVar, Union
 
 # Type aliases for type hints
 


### PR DESCRIPTION
# Pull Request Overview:
- (specify any related issue here)

# Main Changes:
- Operations
- Actions
- Operation Callbac Types
- Serverside Redis Commands (the very minimal)
- "Advanced" section

# Additional Info
Had to do some messing with the types.  Sphinx refuse to leave type aliases "unexpanded" unless importing ``from __future__ import annotations``, which Python 3.6 does not support. 😞 
May remove 3.6 support, but very  silly that the documentation would be the reason for ditching it.. 


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [x] Documentation : Doc-Strings
- [x] Documentation : Usage Guide / Manual
