### PR TITLE
Not reading ALL *.conf files, per default 

### DIFF
--- a/src/redgrease/cli.py
+++ b/src/redgrease/cli.py
@@ -42,7 +42,7 @@ args = configargparse.ArgParser(
     "executes them in a Redis Gears instance or cluster. "
     "Can optionally run continiously, montoring and re-loading scripts "
     "whenever changes are detected.",
-    default_config_files=["./*.conf", "/etc/redgrease/conf.d/*.conf"],
+    default_config_files=["./redgrease.conf", "/etc/redgrease/conf.d/*.conf"],
 )
 
 args.add_argument(
@@ -163,7 +163,7 @@ args.add_argument(
 )
 
 
-config = args.parse_args()
+config = args.parse_known_args()
 
 redgrease.formatting.initialize_logger(config=config.log_config)
 


### PR DESCRIPTION
... as it may conflict with e.g. 'redis.conf'

# Pull Request Overview:
Just changing the default from `*.conf` to `redgrease.conf`

# Main Changes:
- See overview
- Also allowing unknown args, in case someone wants to use the same config for several stuff (Not sure how Redis reacts to unknown args tho).

# Additional Info
Issue arises when running redgrease cli in the same dir as redis-server conf, which is not a completely crazy thing to allow.


# Checklist
(Check those that apply, just so we know)
## Testing
- [ ] Testing : Ad-hoc/manual
- [ ] Testing : Ran relevant PyTest's 
    (I.e some test cases only)
- [ ] Testing : Ran whole PyTest suite 
    (I.e. all test-cases but for one or limited number of environments)
- [x] Testing : Ran whole Travis test suite 
    (I.e. all test-cases across all supported environments)
  
## Documentation
- [ ] Documentation : Type Hints
- [ ] Documentation : Doc-Strings
- [ ] Documentation : Usage Guide / Manual
